### PR TITLE
Server: make bonjour service more discoverable

### DIFF
--- a/xcuitest-server/xcuitest-server/CBXCUITestServer.m
+++ b/xcuitest-server/xcuitest-server/CBXCUITestServer.m
@@ -25,10 +25,11 @@ static CBXCUITestServer *sharedServer;
         sharedServer = [self new];
         sharedServer.server = [[RoutingHTTPServer alloc] init];
         [sharedServer.server setRouteQueue:dispatch_get_main_queue()];
-        [sharedServer.server setDefaultHeader:@"Server" value:@"CalabashXCUITestServer/1.0"];
+        [sharedServer.server setDefaultHeader:@"CalabusDriver"
+                                        value:@"CalabashXCUITestServer/1.0"];
         [sharedServer.server setConnectionClass:[RoutingConnection self]];
-        [sharedServer.server setName:@"Calabus Driver"];
-        [sharedServer.server setType:@"_http._tcp."];
+        [sharedServer.server setName:@"CalabusDriver"];
+        [sharedServer.server setType:@"_calabus._tcp."];
 
         NSDictionary *capabilities =
         @{


### PR DESCRIPTION
### Motivation

```
$ dns-sd -B _calabus._tcp local
Browsing for _calabus._tcp.local
DATE: ---Mon 08 Feb 2016---
23:19:27.713  ...STARTING...
Timestamp     A/R    Flags  if Domain               Service Type         Instance Name
23:19:27.714  Add        2   4 local.               _calabus._tcp.          CalabusDriver

$ dns-sd -L "CalabusDriver" _calabus._tcp.
Lookup Calabus Driver._http._tcp..local
DATE: ---Mon 08 Feb 2016---
23:20:40.110  ...STARTING...
23:20:40.423  CalabusDriver._http._tcp.local. can be reached at Joshuas-iPhone.local.:27753 (interface 4)
 name=Joshua\'s\ iPhone
```
