### PR TITLE
CoordinateQueryConfiguration should always return YES for isCoordinateQuery

### DIFF
--- a/CBXDriver.xcodeproj/project.pbxproj
+++ b/CBXDriver.xcodeproj/project.pbxproj
@@ -25,6 +25,13 @@
 		89512BDC1C9EEC3C0027D61E /* Drag.m in Sources */ = {isa = PBXBuildFile; fileRef = 89512BDA1C9EEC3C0027D61E /* Drag.m */; };
 		89512BDF1CA095D20027D61E /* DeviceEventRoutes.h in Headers */ = {isa = PBXBuildFile; fileRef = 89512BDD1CA095D20027D61E /* DeviceEventRoutes.h */; };
 		89512BE01CA095D20027D61E /* DeviceEventRoutes.m in Sources */ = {isa = PBXBuildFile; fileRef = 89512BDE1CA095D20027D61E /* DeviceEventRoutes.m */; };
+		8965867D1CEB961300E8329C /* QueryConfigurationFactory.m in Sources */ = {isa = PBXBuildFile; fileRef = 8965867B1CEB961000E8329C /* QueryConfigurationFactory.m */; };
+		8965867F1CEB998500E8329C /* QueryConfigurationFactory.m in Sources */ = {isa = PBXBuildFile; fileRef = 8965867B1CEB961000E8329C /* QueryConfigurationFactory.m */; };
+		896586821CEB9B9800E8329C /* QueryFactory.h in Headers */ = {isa = PBXBuildFile; fileRef = 896586801CEB9B9800E8329C /* QueryFactory.h */; };
+		896586831CEB9B9800E8329C /* QueryFactory.m in Sources */ = {isa = PBXBuildFile; fileRef = 896586811CEB9B9800E8329C /* QueryFactory.m */; };
+		896586841CEB9B9800E8329C /* QueryFactory.m in Sources */ = {isa = PBXBuildFile; fileRef = 896586811CEB9B9800E8329C /* QueryFactory.m */; };
+		896586891CEBA0A400E8329C /* QueryConfigurationFactoryTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 896586881CEBA0A400E8329C /* QueryConfigurationFactoryTests.m */; };
+		8965868E1CEBA19A00E8329C /* QueryFactoryTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 8965868D1CEBA19A00E8329C /* QueryFactoryTests.m */; };
 		899696BA1CADF84B00BB42E2 /* EnterText.h in Headers */ = {isa = PBXBuildFile; fileRef = 899696B81CADF84B00BB42E2 /* EnterText.h */; };
 		899696BB1CADF84B00BB42E2 /* EnterText.m in Sources */ = {isa = PBXBuildFile; fileRef = 899696B91CADF84B00BB42E2 /* EnterText.m */; };
 		899696BC1CADF85B00BB42E2 /* EnterText.m in Sources */ = {isa = PBXBuildFile; fileRef = 899696B91CADF84B00BB42E2 /* EnterText.m */; };
@@ -325,6 +332,12 @@
 		89512BDA1C9EEC3C0027D61E /* Drag.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = Drag.m; sourceTree = "<group>"; };
 		89512BDD1CA095D20027D61E /* DeviceEventRoutes.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DeviceEventRoutes.h; sourceTree = "<group>"; };
 		89512BDE1CA095D20027D61E /* DeviceEventRoutes.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = DeviceEventRoutes.m; sourceTree = "<group>"; };
+		8965867A1CEB961000E8329C /* QueryConfigurationFactory.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = QueryConfigurationFactory.h; sourceTree = "<group>"; };
+		8965867B1CEB961000E8329C /* QueryConfigurationFactory.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = QueryConfigurationFactory.m; sourceTree = "<group>"; };
+		896586801CEB9B9800E8329C /* QueryFactory.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = QueryFactory.h; sourceTree = "<group>"; };
+		896586811CEB9B9800E8329C /* QueryFactory.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = QueryFactory.m; sourceTree = "<group>"; };
+		896586881CEBA0A400E8329C /* QueryConfigurationFactoryTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = QueryConfigurationFactoryTests.m; sourceTree = "<group>"; };
+		8965868D1CEBA19A00E8329C /* QueryFactoryTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = QueryFactoryTests.m; sourceTree = "<group>"; };
 		898743BC1C5847B30084FD93 /* CBXAppStub.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = CBXAppStub.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		898743D51C5847B30084FD93 /* CBX.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = CBX.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		899696B81CADF84B00BB42E2 /* EnterText.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = EnterText.h; sourceTree = "<group>"; };
@@ -731,8 +744,7 @@
 			isa = PBXGroup;
 			children = (
 				89331D1F1CC0F72B003C2E59 /* ActionConfigurationTests.m */,
-				89331D211CC1001E003C2E59 /* QueryConfigurationTests.m */,
-				89331D241CC1060A003C2E59 /* CoordinateQueryConfigurationTests.m */,
+				8965868A1CEBA17200E8329C /* QueryConfiguration */,
 			);
 			name = ActionConfiguration;
 			sourceTree = "<group>";
@@ -751,6 +763,62 @@
 				89331D381CC56BE5003C2E59 /* Gestures+OptionsTests.m */,
 			);
 			name = Categories;
+			sourceTree = "<group>";
+		};
+		896586851CEB9B9C00E8329C /* Factory */ = {
+			isa = PBXGroup;
+			children = (
+				896586801CEB9B9800E8329C /* QueryFactory.h */,
+				896586811CEB9B9800E8329C /* QueryFactory.m */,
+			);
+			name = Factory;
+			sourceTree = "<group>";
+		};
+		896586861CEB9BA400E8329C /* Factory */ = {
+			isa = PBXGroup;
+			children = (
+				8965867A1CEB961000E8329C /* QueryConfigurationFactory.h */,
+				8965867B1CEB961000E8329C /* QueryConfigurationFactory.m */,
+			);
+			name = Factory;
+			sourceTree = "<group>";
+		};
+		896586871CEB9BA900E8329C /* QueryConfiguration */ = {
+			isa = PBXGroup;
+			children = (
+				899696C71CB356BF00BB42E2 /* QueryConfiguration.h */,
+				899696C81CB356BF00BB42E2 /* QueryConfiguration.m */,
+				899696E31CB46C0100BB42E2 /* CoordinateQueryConfiguration.h */,
+				899696E41CB46C0100BB42E2 /* CoordinateQueryConfiguration.m */,
+				896586861CEB9BA400E8329C /* Factory */,
+			);
+			name = QueryConfiguration;
+			sourceTree = "<group>";
+		};
+		8965868A1CEBA17200E8329C /* QueryConfiguration */ = {
+			isa = PBXGroup;
+			children = (
+				89331D211CC1001E003C2E59 /* QueryConfigurationTests.m */,
+				89331D241CC1060A003C2E59 /* CoordinateQueryConfigurationTests.m */,
+				8965868B1CEBA18500E8329C /* Factory */,
+			);
+			name = QueryConfiguration;
+			sourceTree = "<group>";
+		};
+		8965868B1CEBA18500E8329C /* Factory */ = {
+			isa = PBXGroup;
+			children = (
+				896586881CEBA0A400E8329C /* QueryConfigurationFactoryTests.m */,
+			);
+			name = Factory;
+			sourceTree = "<group>";
+		};
+		8965868C1CEBA18E00E8329C /* Factory */ = {
+			isa = PBXGroup;
+			children = (
+				8965868D1CEBA19A00E8329C /* QueryFactoryTests.m */,
+			);
+			name = Factory;
 			sourceTree = "<group>";
 		};
 		898743B31C5847B30084FD93 = {
@@ -789,10 +857,7 @@
 				899696D81CB45FFC00BB42E2 /* ActionConfiguration.m */,
 				899696D11CB44D9B00BB42E2 /* GestureConfiguration.h */,
 				899696D21CB44D9B00BB42E2 /* GestureConfiguration.m */,
-				899696C71CB356BF00BB42E2 /* QueryConfiguration.h */,
-				899696C81CB356BF00BB42E2 /* QueryConfiguration.m */,
-				899696E31CB46C0100BB42E2 /* CoordinateQueryConfiguration.h */,
-				899696E41CB46C0100BB42E2 /* CoordinateQueryConfiguration.m */,
+				896586871CEB9BA900E8329C /* QueryConfiguration */,
 			);
 			name = ActionConfiguration;
 			sourceTree = "<group>";
@@ -854,6 +919,7 @@
 				899696F81CB5BA4600BB42E2 /* CoordinateQuery.h */,
 				899696F91CB5BA4600BB42E2 /* CoordinateQuery.m */,
 				89D537F41CA1DD9A00F62E09 /* QuerySelectors */,
+				896586851CEB9B9C00E8329C /* Factory */,
 			);
 			name = Queries;
 			sourceTree = "<group>";
@@ -1495,6 +1561,7 @@
 		F5B0A1961CAD4C9200E056CE /* Queries */ = {
 			isa = PBXGroup;
 			children = (
+				8965868C1CEBA18E00E8329C /* Factory */,
 				F5B0A1971CAD4C9200E056CE /* QuerySelectors */,
 				89331D261CC10857003C2E59 /* QueryTests.m */,
 				89331D281CC1C279003C2E59 /* CoordinateQueryTests.m */,
@@ -1570,6 +1637,7 @@
 				F55F824E1C6DD07500A945C8 /* HTTPResponseProxy.h in Headers */,
 				F55F823A1C6DD07500A945C8 /* ContextFilterLogFormatter.h in Headers */,
 				899696C41CB3360900BB42E2 /* Pinch.h in Headers */,
+				896586821CEB9B9800E8329C /* QueryFactory.h in Headers */,
 				F55F81901C6DD07500A945C8 /* HTTPMessage.h in Headers */,
 				89512BDF1CA095D20027D61E /* DeviceEventRoutes.h in Headers */,
 				89512BDB1C9EEC3C0027D61E /* Drag.h in Headers */,
@@ -1851,6 +1919,7 @@
 				F55F82551C6DD07500A945C8 /* RouteResponse.m in Sources */,
 				89D538091CA32AB000F62E09 /* XCUIElement+WebDriverAttributes.m in Sources */,
 				F55F81861C6DD07500A945C8 /* DDData.m in Sources */,
+				8965867D1CEB961300E8329C /* QueryConfigurationFactory.m in Sources */,
 				F55F840F1C6E437100A945C8 /* UndefinedRoutes.m in Sources */,
 				89D538041CA20DB800F62E09 /* QuerySpecifierByText.m in Sources */,
 				899696BB1CADF84B00BB42E2 /* EnterText.m in Sources */,
@@ -1923,6 +1992,7 @@
 				F55F81961C6DD07500A945C8 /* MultipartFormDataParser.m in Sources */,
 				F55B31C61CBE6EEA00DFB13C /* TwoFingerTap.m in Sources */,
 				F55F81A41C6DD07500A945C8 /* HTTPFileResponse.m in Sources */,
+				896586831CEB9B9800E8329C /* QueryFactory.m in Sources */,
 				F55F81941C6DD07500A945C8 /* HTTPServer.m in Sources */,
 				89D538161CA351F400F62E09 /* QuerySpecifierByIndex.m in Sources */,
 				F55F823D1C6DD07500A945C8 /* DispatchQueueLogFormatter.m in Sources */,
@@ -1969,6 +2039,7 @@
 				F5B0A1AF1CAD4E2700E056CE /* QuerySpecifierFactory.m in Sources */,
 				F5B0A1D61CAD4E8A00E056CE /* HTTPRedirectResponse.m in Sources */,
 				89331D391CC56BE5003C2E59 /* Gestures+OptionsTests.m in Sources */,
+				8965867F1CEB998500E8329C /* QueryConfigurationFactory.m in Sources */,
 				F5B0A11D1CAD3D8C00E056CE /* CBXTestToolsStandup.m in Sources */,
 				F5B0A1A41CAD4DE800E056CE /* XCUIElement+WebDriverAttributes.m in Sources */,
 				F5B0A1D51CAD4E8A00E056CE /* HTTPFileResponse.m in Sources */,
@@ -1978,11 +2049,13 @@
 				F5B0A1CD1CAD4E7500E056CE /* HTTPServer.m in Sources */,
 				F5B0A1CC1CAD4E7500E056CE /* HTTPMessage.m in Sources */,
 				F5B0A1C21CAD4E4600E056CE /* SessionRoutes.m in Sources */,
+				896586841CEB9B9800E8329C /* QueryFactory.m in Sources */,
 				F5B0A1B11CAD4E2700E056CE /* QuerySpecifierByText.m in Sources */,
 				F5B0A1DC1CAD4E9500E056CE /* DDTTYLogger.m in Sources */,
 				F5F49F401CC792A1003F33A6 /* RouteResponseTest.m in Sources */,
 				F5B0A1A31CAD4DE800E056CE /* FBElement.m in Sources */,
 				F5B0A1A71CAD4E2700E056CE /* GestureFactory.m in Sources */,
+				8965868E1CEBA19A00E8329C /* QueryFactoryTests.m in Sources */,
 				F5B0A1B91CAD4E3A00E056CE /* CBXException.m in Sources */,
 				89331D291CC1C279003C2E59 /* CoordinateQueryTests.m in Sources */,
 				89331D2D1CC50172003C2E59 /* GestureFactoryTests.m in Sources */,
@@ -2004,6 +2077,7 @@
 				899696F71CB5B8C300BB42E2 /* Coordinate.m in Sources */,
 				F5B0A1D21CAD4E8A00E056CE /* HTTPDataResponse.m in Sources */,
 				899696CB1CB356BF00BB42E2 /* QueryConfiguration.m in Sources */,
+				896586891CEBA0A400E8329C /* QueryConfigurationFactoryTests.m in Sources */,
 				F5B0A1BC1CAD4E3A00E056CE /* InvalidArgumentException.m in Sources */,
 				F5B0A1D01CAD4E7F00E056CE /* MultipartMessageHeaderField.m in Sources */,
 				F5B0A1E31CAD4EA700E056CE /* RoutingConnection.m in Sources */,

--- a/Server/CoordinateQuery.m
+++ b/Server/CoordinateQuery.m
@@ -5,6 +5,10 @@
 
 @implementation CoordinateQuery
 
+- (BOOL)isCoordinateQuery {
+    return YES;
+}
+
 + (instancetype)withQueryConfiguration:(QueryConfiguration *)queryConfig {
     if (![queryConfig isKindOfClass:[CoordinateQueryConfiguration class]]) {
         @throw [InvalidArgumentException

--- a/Server/CoordinateQueryConfiguration.m
+++ b/Server/CoordinateQueryConfiguration.m
@@ -3,14 +3,6 @@
 #import "JSONUtils.h"
 
 @implementation CoordinateQueryConfiguration
-@synthesize isCoordinateQuery = _isCoordinateQuery;
-
-- (id)init {
-    if (self = [super init]) {
-        _isCoordinateQuery = YES;
-    }
-    return self;
-}
 
 - (BOOL)isCoordinateQuery {
     return YES;

--- a/Server/Gesture.m
+++ b/Server/Gesture.m
@@ -56,7 +56,7 @@
     
     NSMutableArray <Coordinate *> *coords = [NSMutableArray new];
     if (self.query.isCoordinateQuery) {
-        CoordinateQuery *cq = [self.query asCoordinateQuery];
+        CoordinateQuery *cq = (CoordinateQuery *)self.query;
         if (cq.coordinate) {
             [coords addObject:cq.coordinate];
         }

--- a/Server/GestureFactory.m
+++ b/Server/GestureFactory.m
@@ -1,5 +1,7 @@
 
+#import "QueryConfigurationFactory.h"
 #import "InvalidArgumentException.h"
+#import "QueryFactory.h"
 #import "GestureFactory.h"
 #import <objc/runtime.h>
 
@@ -41,9 +43,11 @@ static NSMutableSet <Class> *gestureClasses;
         if (c != [Gesture class] && [gesture isEqualToString:[c name]]) {
             GestureConfiguration *gestureConfig = [GestureConfiguration withJSON:options
                                                                        validator:[c validator]];
-            QueryConfiguration *queryConfig = [QueryConfiguration withJSON:specifiers
-                                                                 validator:[Query validator]];
-            Query *query = [Query withQueryConfiguration:queryConfig];
+            
+            QueryConfiguration *queryConfig = [QueryConfigurationFactory configWithJSON:specifiers
+                                                                              validator:[Query validator]];
+            
+            Query *query = [QueryFactory queryWithQueryConfiguration:queryConfig];
             return [c executeWithGestureConfiguration:gestureConfig
                                                 query:query
                                            completion:completion];

--- a/Server/Query.h
+++ b/Server/Query.h
@@ -23,18 +23,18 @@ NS_ASSUME_NONNULL_BEGIN
 - (id)objectForKeyedSubscript:(NSString *)key;
 
 /**
- Convenience property for determining if the Query can be treated as a 
+ Convenience method for determining if the Query can be treated as a
  CoordinateQuery. 
  
  Coordinate-based queries are a special case of Query, since (in the case of
  Gestures) they already provide enough information to perform the gesture without
  needing to resolve any higher-level specifiers.
  
- It is therefore helpful to have a convenience property that indicates whether or 
+ It is therefore helpful to have a convenience method that indicates whether or
  not a Query should be treeted as a CoordinateQuery, since it is able to short-circuit
  the query evaluation logic for performing gestures.
  */
-@property (nonatomic) BOOL isCoordinateQuery;
+- (BOOL)isCoordinateQuery;
 
 
 /**

--- a/Server/Query.m
+++ b/Server/Query.m
@@ -13,11 +13,8 @@
                                  optionalKeys:[QuerySpecifierFactory supportedSpecifierNames]];
 }
 
-- (id)init {
-    if (self = [super init]) {
-        self.isCoordinateQuery = NO;
-    }
-    return self;
+- (BOOL)isCoordinateQuery {
+    return NO;
 }
 
 - (CoordinateQuery *)asCoordinateQuery {
@@ -27,7 +24,6 @@
 + (instancetype)withQueryConfiguration:(QueryConfiguration *)queryConfig {
     Query *e = [self new];
     e.queryConfiguration = queryConfig;
-    e.isCoordinateQuery = queryConfig.isCoordinateQuery;
     return e;
 }
 

--- a/Server/QueryConfiguration.h
+++ b/Server/QueryConfiguration.h
@@ -26,13 +26,13 @@
 @property (nonatomic, strong) NSArray <QuerySpecifier *> *selectors;
 
 /**
- A convenience getter for checking if a QueryConfiguration is actually a CoordinateQueryConfiguration
+ A convenience method for checking if a QueryConfiguration is actually a CoordinateQueryConfiguration
  
  CoordinateQueries don't follow the normal chaining logic of XCUITestQueries
  (they are a one-shot operation). Therefore, it's helpful for a query evaluator
  to know if a Query's config indicates that it is a coordinate query.
  */
-@property (nonatomic, readonly) BOOL isCoordinateQuery;
+- (BOOL)isCoordinateQuery;
 
 /**
  If a the current query config is in fact a coordinate query config, 

--- a/Server/QueryConfiguration.m
+++ b/Server/QueryConfiguration.m
@@ -13,9 +13,12 @@
 - (id)init {
     if (self = [super init]) {
         self.selectors = [NSMutableArray array];
-        _isCoordinateQuery = NO;
     }
     return self;
+}
+
+- (BOOL)isCoordinateQuery {
+    return NO;
 }
 
 + (NSMutableDictionary *)specifiersFromQueryString:(NSString *)queryString {
@@ -31,15 +34,6 @@
     NSMutableArray *selectors = [NSMutableArray array];
 
     for (NSString *key in keys) {
-        /*
-            If we're dealing with a coordinate query, selectors don't matter since the element
-            should be uniquely identified by the coordinates.
-         */
-        if ([key isEqualToString:CBX_COORDINATE_KEY] ||
-            [key isEqualToString:CBX_COORDINATES_KEY]) {
-            _isCoordinateQuery = YES;
-            break;
-        }
         QuerySpecifier *qs = [QuerySpecifierFactory specifierWithKey:key
                                                                value:self[key]];
         if (qs) {

--- a/Server/QueryConfigurationFactory.h
+++ b/Server/QueryConfigurationFactory.h
@@ -1,0 +1,22 @@
+
+#import <Foundation/Foundation.h>
+#import "CoordinateQueryConfiguration.h"
+
+/**
+ Simple factory class for creating QueryConfiguration objects.
+ */
+@interface QueryConfigurationFactory : NSObject
+
+/**
+ Basic static factory constructor for creating a QueryConfiguration.
+ 
+ **This should be used instead of direct instantiation, unless you're sure you know
+ which class you want to instantiate.**
+ 
+ @param json Raw key-value pairs which comprise the query configuration
+ @param validator Used to validate the `json` input
+ @return QueryConfiguration or CoordinateQueryConfiguration as appropriate, based on `json` input
+ */
++ (QueryConfiguration *)configWithJSON:(NSDictionary *)json
+                             validator:(JSONKeyValidator *)validator;
+@end

--- a/Server/QueryConfigurationFactory.m
+++ b/Server/QueryConfigurationFactory.m
@@ -1,0 +1,22 @@
+
+#import "QueryConfigurationFactory.h"
+
+#import "QueryConfiguration.h"
+#import "CoordinateQueryConfiguration.h"
+
+@implementation QueryConfigurationFactory
++ (QueryConfiguration *)configWithJSON:(NSDictionary *)json
+                             validator:(JSONKeyValidator *)validator {
+    for (NSString *key in json) {
+        /*
+         If there are any keys which indicate coordinates, then we treat the object
+         as a CoordinateQueryConfiguration
+         */
+        if ([key isEqualToString:CBX_COORDINATE_KEY] ||
+            [key isEqualToString:CBX_COORDINATES_KEY]) {
+            return [CoordinateQueryConfiguration withJSON:json validator:validator];
+        }
+    }
+    return [QueryConfiguration withJSON:json validator:validator];
+}
+@end

--- a/Server/QueryFactory.h
+++ b/Server/QueryFactory.h
@@ -1,0 +1,20 @@
+
+#import <Foundation/Foundation.h>
+
+#import "CoordinateQuery.h"
+
+/**
+ A simple factory class for creating Query objects.
+ */
+@interface QueryFactory : NSObject
+/**
+ Basic static factory constructor for creating a Query object.
+ 
+ **This should be used instead of direct instantiation, unless you're sure you know
+ which class you want to instantiate.**
+ 
+ @param queryConfig A QueryConfiguration or CoordinateQueryConfiguration
+ @return Query or CoordinateQuery as appropriate, based on `queryConfig`
+ */
++ (Query *_Nonnull)queryWithQueryConfiguration:(QueryConfiguration *_Nonnull)queryConfig;
+@end

--- a/Server/QueryFactory.m
+++ b/Server/QueryFactory.m
@@ -1,0 +1,13 @@
+
+#import "QueryFactory.h"
+#import "CoordinateQuery.h"
+
+@implementation QueryFactory
++ (Query *)queryWithQueryConfiguration:(QueryConfiguration *_Nonnull)queryConfig {
+    if ([queryConfig isCoordinateQuery]) {
+        return [CoordinateQuery withQueryConfiguration:queryConfig];
+    } else {
+        return [Query withQueryConfiguration:queryConfig];
+    }
+}
+@end

--- a/Server/Routes/QueryRoutes.m
+++ b/Server/Routes/QueryRoutes.m
@@ -3,9 +3,11 @@
 //  xcuitest-server
 //
 
+#import "QueryConfigurationFactory.h"
 #import "Application+Queries.h"
-#import "QueryRoutes.h"
 #import "CBXConstants.h"
+#import "QueryFactory.h"
+#import "QueryRoutes.h"
 #import "JSONUtils.h"
 #import "Query.h"
 
@@ -17,9 +19,9 @@
              }],
              
              [CBXRoute post:@"/1.0/query" withBlock:^(RouteRequest *request, NSDictionary *body, RouteResponse *response) {
-                 QueryConfiguration *queryConfig = [QueryConfiguration withJSON:body
-                                                                      validator:[Query validator]];
-                 Query *query = [Query withQueryConfiguration:queryConfig];
+                 QueryConfiguration *queryConfig = [QueryConfigurationFactory configWithJSON:body
+                                                                                   validator:[Query validator]];
+                 Query *query = [QueryFactory queryWithQueryConfiguration:queryConfig];
                  
                  NSArray <XCUIElement *> *elements = [query execute];
                  

--- a/UnitTest/Tests/Gestures/Gestures+OptionsTests.m
+++ b/UnitTest/Tests/Gestures/Gestures+OptionsTests.m
@@ -1,6 +1,8 @@
 
-#import <XCTest/XCTest.h>
+#import "QueryConfigurationFactory.h"
 #import "Gesture+Options.h"
+#import <XCTest/XCTest.h>
+#import "QueryFactory.h"
 #import "EnterTextIn.h"
 #import "EnterText.h"
 #import "DoubleTap.h"
@@ -33,12 +35,14 @@
 
     GestureConfiguration *config = [GestureConfiguration withJSON:json[@"options"]
                                                         validator:[gestureClass validator]];
-    Query *query = [Query withQueryConfiguration:[QueryConfiguration withJSON:json[@"specifiers"]
-                                                                    validator:[Query validator]]];
+    
+    QueryConfiguration *queryConfig = [QueryConfigurationFactory configWithJSON:json[@"specifiers"]
+                                                                      validator:[Query validator]];
+    
+    Query *query = [QueryFactory queryWithQueryConfiguration:queryConfig];
     Gesture *g = [gestureClass executeWithGestureConfiguration:config
                                                          query:query
                                                     completion:^(NSError *e){}];
-    
     
     XCTAssertEqualWithAccuracy([g pinchAmount],
                                [config has:CBX_PINCH_AMOUNT_KEY] ?

--- a/UnitTest/Tests/Queries/QueryFactoryTests.m
+++ b/UnitTest/Tests/Queries/QueryFactoryTests.m
@@ -1,0 +1,30 @@
+
+#import "QueryConfigurationFactory.h"
+#import "QueryFactory.h"
+#import <XCTest/XCTest.h>
+
+@interface QueryFactoryTests : XCTestCase
+
+@end
+
+@implementation QueryFactoryTests
+
+- (void)testQuery{
+    QueryConfiguration *config = [QueryConfigurationFactory configWithJSON:@{}
+                                                                 validator:nil];
+    Query *query = [QueryFactory queryWithQueryConfiguration:config];
+    XCTAssertFalse(query.isCoordinateQuery, @"Non coordinate config was treated as CoordinateQuery");
+    XCTAssertFalse([query isKindOfClass:[CoordinateQuery class]],
+                   @"Non coordinate config returned as an instance of CoordinateQuery");
+}
+
+- (void)testCoordinateQuery {
+    QueryConfiguration *config = [QueryConfigurationFactory configWithJSON:@{@"coordinate" : @[@(5), @(5)]}
+                                                                 validator:nil];
+    Query *query = [QueryFactory queryWithQueryConfiguration:config];
+    XCTAssertTrue(query.isCoordinateQuery, @"Non coordinate config was treated as CoordinateQuery");
+    XCTAssertTrue([query isKindOfClass:[CoordinateQuery class]],
+                   @"Non coordinate config returned as an instance of CoordinateQuery");
+}
+
+@end

--- a/UnitTest/Tests/Queries/QueryTests.m
+++ b/UnitTest/Tests/Queries/QueryTests.m
@@ -1,6 +1,7 @@
 
-#import "Query.h"
+#import "QueryConfigurationFactory.h"
 #import "CoordinateQueryConfiguration.h"
+#import "QueryFactory.h"
 #import "Application.h"
 #import "JSONUtils.h"
 #import <XCTest/XCTest.h>
@@ -20,9 +21,10 @@
     _validQueryConfig = [QueryConfiguration withJSON:json validator:nil];
     
     json = @{@"coordinate" : @[ @2, @2 ]};
-    _validCoordinateQueryConfig = [CoordinateQueryConfiguration withJSON:json validator:nil];
+    _validCoordinateQueryConfig = (CoordinateQueryConfiguration *)
+        [QueryConfigurationFactory configWithJSON:json validator:nil];
     
-    _emptyQueryConfig = [QueryConfiguration withJSON:@{} validator:nil];
+    _emptyQueryConfig = [QueryConfigurationFactory configWithJSON:@{} validator:nil];
     
 }
 
@@ -32,19 +34,19 @@
 }
 
 - (void)testIsCoordinateCarriedFromConfig {
-    Query *query = [Query withQueryConfiguration:_validQueryConfig];
+    Query *query = [QueryFactory queryWithQueryConfiguration:_validQueryConfig];
     XCTAssertFalse(query.isCoordinateQuery,
                    @"Query given %@ thinks it is a coordinate query",
                    _validQueryConfig.raw);
     
-    query = [Query withQueryConfiguration:_validCoordinateQueryConfig];
+    query = [QueryFactory queryWithQueryConfiguration:_validCoordinateQueryConfig];
     XCTAssertTrue(query.isCoordinateQuery,
                   @"Query given %@ does not think it's a coordinate query",
                   _validCoordinateQueryConfig.raw);
 }
 
 - (void)testExecuteWithNoSpecifiers {
-    Query *query = [Query withQueryConfiguration:_emptyQueryConfig];
+    Query *query = [QueryFactory queryWithQueryConfiguration:_emptyQueryConfig];
     id XCUIElementQueryMock = OCMClassMock([XCUIElementQuery class]);
     OCMStub([XCUIElementQueryMock allElementsBoundByIndex]).andReturn(@[[XCUIElement new]]);
 
@@ -55,7 +57,7 @@
     
     id results = @[];
     
-    Query *query = [Query withQueryConfiguration:_validQueryConfig];
+    Query *query = [QueryFactory queryWithQueryConfiguration:_validQueryConfig];
     
     OCMStub([OCMClassMock([Application class]) currentApplication])
     .andReturn([[XCUIApplication alloc] initPrivateWithPath:nil
@@ -72,7 +74,7 @@
 }
 
 - (void)testToJSONString {
-    Query *query = [Query withQueryConfiguration:_validQueryConfig];
+    Query *query = [QueryFactory queryWithQueryConfiguration:_validQueryConfig];
     expect([query toJSONString]).to.equal([JSONUtils objToJSONString:_validQueryConfig.raw]);
 }
 

--- a/UnitTest/Tests/QueryConfigurationFactoryTests.m
+++ b/UnitTest/Tests/QueryConfigurationFactoryTests.m
@@ -1,0 +1,27 @@
+
+#import "QueryConfigurationFactory.h"
+#import <XCTest/XCTest.h>
+
+@interface QueryConfigurationFactoryTests : XCTestCase
+
+@end
+
+@implementation QueryConfigurationFactoryTests
+
+- (void)testQueryConfiguration {
+    QueryConfiguration *config = [QueryConfigurationFactory configWithJSON:@{}
+                                                                 validator:nil];
+    XCTAssertFalse(config.isCoordinateQuery, @"Non coordinate config was treated as coordinate config");
+    XCTAssertFalse([config isKindOfClass:[CoordinateQueryConfiguration class]],
+                   @"Non coordinate config returned as an instance of CoordinateQueryConfiguration");
+}
+
+- (void)testCoordinateQueryConfiguration {
+    QueryConfiguration *config = [QueryConfigurationFactory configWithJSON:@{@"coordinate" : @[@(5), @(5)]}
+                                                                 validator:nil];
+    XCTAssertTrue(config.isCoordinateQuery, @"Non coordinate config was treated as coordinate config");
+    XCTAssertTrue([config isKindOfClass:[CoordinateQueryConfiguration class]],
+                   @"Non coordinate config returned as an instance of CoordinateQueryConfiguration");
+}
+
+@end

--- a/UnitTest/Tests/QueryConfigurationTests.m
+++ b/UnitTest/Tests/QueryConfigurationTests.m
@@ -1,7 +1,6 @@
 
 #import <XCTest/XCTest.h>
-#import "QueryConfiguration.h"
-#import "CoordinateQueryConfiguration.h"
+#import "QueryConfigurationFactory.h"
 
 @interface QueryConfigurationTests : XCTestCase
 
@@ -30,7 +29,7 @@
 
 - (void)testIsCoordinateQuery {
     id json = @{@"coordinate" : @[@1, @2]};
-    QueryConfiguration *config = [QueryConfiguration withJSON:json validator:nil];
+    QueryConfiguration *config = [CoordinateQueryConfiguration withJSON:json validator:nil];
     XCTAssertTrue(config.isCoordinateQuery,
                    @"QueryConfiguration given %@ thinks it's not a coordinate query",
                    json);


### PR DESCRIPTION
### Motivation
- DeviceAgent unit and integration tests are failing [#220](https://github.com/xamarinhq/test-cloud-frameworks/issues/220)

The `init` method of CoordinateQueryConfiguration is never called, so the ivar is never set.
