### PR TITLE
Server: remove Gesture setup method

### DIFF
--- a/Server/Gesture.h
+++ b/Server/Gesture.h
@@ -115,15 +115,6 @@ An array of optional keys for the gesture (e.g., `degrees` for `rotate`). These
 - (void)execute:(CompletionBlock)completion;
 
 /**
- A convenience method that _can_ be called by eventWithCoordinates: or
- gestureWithCoordinates: as a shared setup routine.
-
- @param coords  Should correspond to the `coordinates` param of eventWithCoordinates:
- or gestureWithCoordinates:
- */
-- (id)setup:(NSArray <Coordinate *> *)coords;
-
-/**
  Validates a Gesture or throws an exception. By default, the gesture is assumed to be valid.
  However, subclasses of Gesture can override this method to provide actual validation logic.
 

--- a/Server/Gesture.m
+++ b/Server/Gesture.m
@@ -53,8 +53,6 @@
     //Just assume it's valid by default?
 }
 
-- (id)setup:(NSArray<Coordinate *> *)coords { return nil; }
-
 - (void)execute:(CompletionBlock)completion {
     [self validate];
     


### PR DESCRIPTION
### Motivation

The implementation is empty and the method is never called.
