### PR TITLE
Server: CBXException name should be subclass name

### DIFF
--- a/Server/Exceptions/CBXException.m
+++ b/Server/Exceptions/CBXException.m
@@ -24,7 +24,8 @@
 }
 
 + (instancetype)withMessage:(NSString *)message statusCode:(NSInteger)code userInfo:(NSDictionary *)userInfo {
-    CBXException *e = [[self alloc] initWithName:@"Exception" reason:message userInfo:userInfo];
+    NSString *name = NSStringFromClass([self class]);
+    CBXException *e = [[self alloc] initWithName:name reason:message userInfo:userInfo];
     e.HTTPErrorStatusCode = code;
     return e;
 }


### PR DESCRIPTION
### Motivation

When testing validations, I noticed that this Expecta pattern was not working

``` Objective-C
  expect(^{
      [touch validate];
    }).to.raise(@"InvalidArgumentException");
```

because the _name_ of the exception was always "Exception".
