### PR TITLE
Add '/status' route (for lxc containers)

### DIFF
--- a/Server/Routes/HealthRoutes.m
+++ b/Server/Routes/HealthRoutes.m
@@ -19,6 +19,12 @@
                                              @"status" : @"honk"
                                              }];
              }],
+             
+             [CBXRoute get:@"/status" withBlock:^(RouteRequest *request, NSDictionary *body, RouteResponse *response) {
+                 [response respondWithJSON:@{
+                                             @"status" : @"DeviceAgent is ready and waiting."
+                                             }];
+             }],
            ];
 }
 @end


### PR DESCRIPTION
The LXC infrastructure wants every service to respond to a `/status` endpoint. 

Without getting into details, it's easier to just add one to DeviceAgent than modify the LXC infra. 
