### PR TITLE
Update xctestconfiguration plist for keys 'initializeForUITesting' and 'reportResultsToIDE'

### DIFF
--- a/TestManagerDConnection/CBX-BEEFBABE-FEED-BABE-BEEF-CAFEBEEFFACE.xctestconfiguration
+++ b/TestManagerDConnection/CBX-BEEFBABE-FEED-BABE-BEEF-CAFEBEEFFACE.xctestconfiguration
@@ -35,7 +35,7 @@
 			<key>reportActivities</key>
 			<true/>
 			<key>reportResultsToIDE</key>
-			<true/>
+			<false/>
 			<key>sessionIdentifier</key>
 			<dict>
 				<key>CF$UID</key>


### PR DESCRIPTION
### Motivation

I was reviewing the logs from `xcodebuild test` and saw that our configuration file was in sync with the key/value pairs of the configuration generated by Xcode.

I made these changes in the context of debugging why the server and/or the `testRunner` test does not start.
### Test

For Xcode 7.3.1, these changes had no effect - the "cannot run more than N times" problem persisted.

For Xcode 8.0b3, I found I could run with `xcodebuild` with these changes and the changes to the server in #127.  I have not run against 8.0b3 _without_ these changes - I am waiting on PRs to be merged.  I don't, in other words, know that these changes fix anything.

What do you think Chris?
