### PR TITLE
CBXAppStub: bundle identifier is sh.calaba.CBXAppStub

### DIFF
--- a/CBXDriver.xcodeproj/project.pbxproj
+++ b/CBXDriver.xcodeproj/project.pbxproj
@@ -2536,7 +2536,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				ONLY_ACTIVE_ARCH = NO;
-				PRODUCT_BUNDLE_IDENTIFIER = sh.calabash.CBXAppStub;
+				PRODUCT_BUNDLE_IDENTIFIER = sh.calaba.CBXAppStub;
 				PRODUCT_NAME = CBXAppStub;
 			};
 			name = Debug;
@@ -2554,7 +2554,7 @@
 				INFOPLIST_PREPROCESS = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = sh.calabash.CBXAppStub;
+				PRODUCT_BUNDLE_IDENTIFIER = sh.calaba.CBXAppStub;
 				PRODUCT_NAME = CBXAppStub;
 			};
 			name = Release;


### PR DESCRIPTION
### Motivation

I noticed that the Team Wildcard profile was being use to sign this app.

`sh.calaba.CBXAppStub` is the correct reverse DNS identifier.
