### PR TITLE
Server: patch /enter_text for iOS 10 physical devices

### DIFF
--- a/Server/EnterText.m
+++ b/Server/EnterText.m
@@ -3,6 +3,7 @@
 #import "Testmanagerd.h"
 #import "ThreadUtils.h"
 #import "EnterText.h"
+#import "Application.h"
 
 @implementation EnterText
 
@@ -24,16 +25,24 @@
     }
     
     NSString *string = gestureConfig[CBX_STRING_KEY];
+
+// Original implementation - not working on iOS 10 physical devices
+// https://xamarin.atlassian.net/browse/TCFW-333
+//
+//    [ThreadUtils runSync:^(BOOL *setToTrueWhenDone, NSError *__autoreleasing *err) {
+//        [[Testmanagerd get] _XCT_sendString:string
+//         maximumFrequency:CBX_DEFAULT_SEND_STRING_FREQUENCY
+//                                 completion:^(NSError *e) {
+//            *err = e;
+//            *setToTrueWhenDone = YES;
+//        }];
+//    } completion:completion];
+
+    // This is working on iOS 9 - 10 sims and physical devices.
+    XCUIApplication *application = [Application currentApplication];
+    [application typeText:string];
     
-    [ThreadUtils runSync:^(BOOL *setToTrueWhenDone, NSError *__autoreleasing *err) {
-        [[Testmanagerd get] _XCT_sendString:string
-         maximumFrequency:CBX_DEFAULT_SEND_STRING_FREQUENCY
-                                 completion:^(NSError *e) {
-            *err = e;
-            *setToTrueWhenDone = YES;
-        }];
-    } completion:completion];
-    
+    completion(nil);
     return nil;
 }
 


### PR DESCRIPTION
### Motivation

We are transitioning to iOS 10/Xcode 8 testing.  At the moment, /enter_text fails on iOS 10 physical devices.  I have been holding off on a PR for about a week and distributing it with run_loop.

Progress on:
- DeviceAgent enter_text gesture is not working on iOS 10 physical devices [JIRA](https://xamarin.atlassian.net/browse/TCFW-333)
### Test

More information can be found in the JIRA issue.

```
# If you use bundler to manage a local install of run-loop (you know who you are).
$ cd path/to/run_loop
$ git co develop
$ git pull

$ cd path/to/DeviceAgent.iOS
$ git pull
$ git co -t origin/feature/patch-enter_text-for-iOS-10-physical-devices

# Make and install the TestApp on an iOS 10 physical device
$ make test-ipa
$ ideviceinstaller -u < > Products/ipa/TestApp/TestApp.ipa

$ cd cucumber
$ bundle update
$ DEVELOPER_DIR=/Xcode/8.0/Xcode-beta.app/Contents/Developer \
   DEBUG=1 \
   DEVICE_TARGET=hat \
   DEVICE_ENDPOINT=http://hat.local:37265 \
   be cucumber -t @keyboard
```
