### PR TITLE
DeviceAgent: bumping version to 0.0.3

### DIFF
--- a/CBXAppStub/Info.plist
+++ b/CBXAppStub/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.0.2</string>
+	<string>0.0.3</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>


### PR DESCRIPTION
### Motivation

We are at the point where we should be versioning DeviceAgent.

We need to be able to say, "Oh, that is in version 0.0.3".
### 0.0.3
- Add Scrolliplications view  #138 
- Cucumbers for testing flick, swipe, and scroll using /drag route  #137 
- JSON representation of XCUIElements includes hitpoint info 
- Server: patch /enter_text for iOS 10 physical devices 
- TestApp: add XCUITest for text entry 
- GET /version reports DeviceAgent version #133
- Add XCUITest bundle to TestApp  #132 
- TestApp: link the calabash.framework #131
