### PR TITLE
Update xctestconfiguration

### DIFF
--- a/TestManagerDConnection/CBX-BEEFBABE-FEED-BABE-BEEF-CAFEBEEFFACE.xctestconfiguration
+++ b/TestManagerDConnection/CBX-BEEFBABE-FEED-BABE-BEEF-CAFEBEEFFACE.xctestconfiguration
@@ -103,7 +103,7 @@
 				<integer>3</integer>
 			</dict>
 		</dict>
-		<string>file:///private/var/containers/Bundle/Application/21A83AF9-9B32-4BF6-A016-00605F990879/UITest-Runner.app/PlugIns/UITest.xctest</string>
+		<string>file:///private/var/containers/Bundle/Application/21A83AF9-FACE-FACE-FACE-00605F990879/UITest-Runner.app/PlugIns/UITest.xctest</string>
 		<dict>
 			<key>$classes</key>
 			<array>
@@ -133,7 +133,7 @@
 			<key>$classname</key>
 			<string>NSUUID</string>
 		</dict>
-		<string>/Users/moody/Library/Developer/Xcode/DerivedData/CBXDriver-aewnlqtolcmvwhfyuphfblhkryeq/Build/Products/Debug-iphoneos/TestApp.app</string>
+		<string>/Users/calabash/Library/Developer/Xcode/DerivedData/CBXDriver-thankyouforusingcalabash/Build/Products/Debug-iphoneos/TestApp.app</string>
 		<string>sh.calaba.TestApp</string>
 		<string>UITest</string>
 		<dict>


### PR DESCRIPTION
Upon updating the xctestconfiguration (it seems to have more fields since Xcode7 / 8b1), I can now use `ideviceteststarter` to start a test on iOS10b6 on iPhone6 and 5. 

**Note** that DeviceAgent.iOS must have been installed from Xcode. Unclear if there's something magical about it, but it seems our resigning process (or something) is corrupting the build trying to install manually outside of xcode. 

CC: @jmoody @john7doe 
