### PR TITLE
Bin: scripts for extracting codesign details from artifacts

### DIFF
--- a/bin/codesign/entitlements.sh
+++ b/bin/codesign/entitlements.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+xcrun codesign -d --entitlements :- "${1}"

--- a/bin/codesign/signed.sh
+++ b/bin/codesign/signed.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+xcrun codesign --display --verbose=4 "${1}"

--- a/bin/codesign/verify.sh
+++ b/bin/codesign/verify.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+xcrun codesign \
+  --verify -vvvv \
+  -R='anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.1] exists and (certificate leaf[field.1.2.840.113635.100.6.1.2] exists or certificate leaf[field.1.2.840.113635.100.6.1.4] exists)' \
+  "${1}"


### PR DESCRIPTION
### Motivation

Scripts to make inspecting .app bundles and executables easier.

```
$ bin/codesign/signed.sh
$ bin/codesign/entitlements.sh
$ bin/codesign/verify.sh
```
