### PR TITLE
Cucumber: use :automator instead of :gesture_performer

### DIFF
--- a/cucumber/features/support/01_launch.rb
+++ b/cucumber/features/support/01_launch.rb
@@ -82,12 +82,12 @@ Before do |scenario|
     :simctl => launcher.simctl,
     :instruments => launcher.instruments,
     :app => launcher.app,
-    :gesture_performer => :device_agent,
+    :automator => :device_agent,
     #:cbx_launcher => :xcodebuild,
 
     # Keep this as true.  The Launcher singleton ensures
-    # that the DeviceAgent-Runner is launched only once on physical
-    # devices.
+    # that the DeviceAgent-Runner is launched only once
+    # on physical devices.
     :shutdown_device_agent_before_launch => true
   }
 


### PR DESCRIPTION
### Motivation

run_loop 2.1.9 uses `:automator` instead of `:gesture_performer` to branch on automation framework.

Only effects Xcode 7.3.1 tests where it is possible to run with :instruments or :device_agent.
