### PR TITLE
DeviceAgent: use FBFailureProofTestCase

### DIFF
--- a/DeviceAgent.xcodeproj/project.pbxproj
+++ b/DeviceAgent.xcodeproj/project.pbxproj
@@ -160,6 +160,8 @@
 		F5169D231CFE07FD00252F52 /* LICENSE in Resources */ = {isa = PBXBuildFile; fileRef = F5169D211CFE07F500252F52 /* LICENSE */; };
 		F5169D241CFE07FE00252F52 /* LICENSE in Resources */ = {isa = PBXBuildFile; fileRef = F5169D211CFE07F500252F52 /* LICENSE */; };
 		F5169D251CFE07FF00252F52 /* LICENSE in Resources */ = {isa = PBXBuildFile; fileRef = F5169D211CFE07F500252F52 /* LICENSE */; };
+		F519E0FE1D79E336003A84B0 /* FBFailureProofTestCase.h in Headers */ = {isa = PBXBuildFile; fileRef = F519E0F81D79E336003A84B0 /* FBFailureProofTestCase.h */; };
+		F519E0FF1D79E336003A84B0 /* FBFailureProofTestCase.m in Sources */ = {isa = PBXBuildFile; fileRef = F519E0F91D79E336003A84B0 /* FBFailureProofTestCase.m */; };
 		F52975BF1D4FB1FA009094D5 /* CBXUITestServerTest.m in Sources */ = {isa = PBXBuildFile; fileRef = F52975BE1D4FB1FA009094D5 /* CBXUITestServerTest.m */; };
 		F52BA3411CED1F9C00475D5A /* Reveal.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F52BA33F1CED1F6A00475D5A /* Reveal.framework */; };
 		F52BA3431CED23E400475D5A /* CoreGraphics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F542EA201CC53F6400D87200 /* CoreGraphics.framework */; };
@@ -557,6 +559,8 @@
 		F5169D131CFE06B700252F52 /* Fingertips.LICENSE */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = Fingertips.LICENSE; sourceTree = "<group>"; };
 		F5169D141CFE06B700252F52 /* RoutingHTTPServer.LICENSE */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = RoutingHTTPServer.LICENSE; sourceTree = "<group>"; };
 		F5169D211CFE07F500252F52 /* LICENSE */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = LICENSE; sourceTree = "<group>"; };
+		F519E0F81D79E336003A84B0 /* FBFailureProofTestCase.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FBFailureProofTestCase.h; sourceTree = "<group>"; };
+		F519E0F91D79E336003A84B0 /* FBFailureProofTestCase.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FBFailureProofTestCase.m; sourceTree = "<group>"; };
 		F52975BE1D4FB1FA009094D5 /* CBXUITestServerTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CBXUITestServerTest.m; sourceTree = "<group>"; };
 		F52BA33F1CED1F6A00475D5A /* Reveal.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = Reveal.framework; sourceTree = "<group>"; };
 		F52BA3441CED23EC00475D5A /* libz.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libz.tbd; path = usr/lib/libz.tbd; sourceTree = SDKROOT; };
@@ -1313,8 +1317,10 @@
 		F55F83541C6DD99900A945C8 /* DeviceAgent */ = {
 			isa = PBXGroup;
 			children = (
-				F55F83551C6DD99900A945C8 /* Info.plist */,
 				F55F83561C6DD99900A945C8 /* TestRunner.m */,
+				F519E0F81D79E336003A84B0 /* FBFailureProofTestCase.h */,
+				F519E0F91D79E336003A84B0 /* FBFailureProofTestCase.m */,
+				F55F83551C6DD99900A945C8 /* Info.plist */,
 			);
 			path = DeviceAgent;
 			sourceTree = "<group>";
@@ -1930,6 +1936,7 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				F519E0FE1D79E336003A84B0 /* FBFailureProofTestCase.h in Headers */,
 				89C5F36F1C9E32440093A018 /* DoubleTap.h in Headers */,
 				899696D91CB45FFC00BB42E2 /* ActionConfiguration.h in Headers */,
 				899696BF1CB2F22000BB42E2 /* EnterTextIn.h in Headers */,
@@ -2405,6 +2412,7 @@
 				F55F840C1C6E437100A945C8 /* MetaRoutes.m in Sources */,
 				F55F818E1C6DD07500A945C8 /* HTTPConnection.m in Sources */,
 				89D538111CA34CBE00F62E09 /* QuerySpecifierByTextLike.m in Sources */,
+				F519E0FF1D79E336003A84B0 /* FBFailureProofTestCase.m in Sources */,
 				89331D321CC50447003C2E59 /* ThreadUtils.m in Sources */,
 				89D5381A1CA3551600F62E09 /* QuerySpecifierByProperty.m in Sources */,
 				F55F82511C6DD07500A945C8 /* Route.m in Sources */,

--- a/DeviceAgent/FBFailureProofTestCase.h
+++ b/DeviceAgent/FBFailureProofTestCase.h
@@ -1,0 +1,42 @@
+/**
+ * Original copyright notice.
+ *
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ # PATENTS: https://github.com/facebook/WebDriverAgent/blob/master/PATENTS
+ * LICENSE: https://github.com/facebook/WebDriverAgent/blob/master/LICENSE
+ *
+ * The license for this source code can be found in the root directory of this
+ * source tree under Licenses/.
+ */
+ 
+#import <Foundation/Foundation.h>
+#import "XCTestCase.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ Test Case that will never fail or stop from running in case of failure
+ */
+@interface FBFailureProofTestCase : XCTestCase
+@end
+
+/**
+ Class that can be used to proxy existing _XCTestCaseImplementation and
+ prevent currently running test from being terminated on any XCTest failure
+ */
+@interface FBXCTestCaseImplementationFailureHoldingProxy : NSProxy
+
+/**
+ Constructor for given existing _XCTestCaseImplementation instance
+ */
++ (instancetype)proxyWithXCTestCaseImplementation:(_XCTestCaseImplementation *)internalImplementation;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/DeviceAgent/FBFailureProofTestCase.m
+++ b/DeviceAgent/FBFailureProofTestCase.m
@@ -1,0 +1,81 @@
+/**
+ * Original copyright notice.
+ *
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ # PATENTS: https://github.com/facebook/WebDriverAgent/blob/master/PATENTS
+ * LICENSE: https://github.com/facebook/WebDriverAgent/blob/master/LICENSE
+ *
+ * The license for this source code can be found in the root directory of this
+ * source tree under Licenses/.
+ */
+
+#import "FBFailureProofTestCase.h"
+#import "_XCTestCaseImplementation.h"
+
+@interface FBFailureProofTestCase ()
+@property (nonatomic, assign) BOOL didRegisterAXTestFailure;
+@end
+
+@implementation FBFailureProofTestCase
+
+- (void)setUp {
+  [super setUp];
+  self.continueAfterFailure = YES;
+  self.internalImplementation = (_XCTestCaseImplementation *)[FBXCTestCaseImplementationFailureHoldingProxy
+  proxyWithXCTestCaseImplementation:self.internalImplementation];
+}
+
+/**
+ Private XCTestCase method used to block and tunnel failure messages
+ */
+- (void)_enqueueFailureWithDescription:(NSString *)description
+                                inFile:(NSString *)filePath
+                                atLine:(NSUInteger)lineNumber
+                              expected:(BOOL)expected
+{
+    NSLog(@"Enqueue Failure: %@ %@ %lu %d", description, filePath, (unsigned long)lineNumber, expected);
+    const BOOL isPossibleDeadlock = ([description rangeOfString:@"Failed to get refreshed snapshot"].location != NSNotFound);
+    if (!isPossibleDeadlock) {
+        self.didRegisterAXTestFailure = YES;
+    } else if (self.didRegisterAXTestFailure) {
+        self.didRegisterAXTestFailure = NO; // Reseting to NO to enable future deadlock detection
+        [[NSException exceptionWithName:@"DeviceAgentDeadlockDetectedException"
+                                 reason:@"Can't communicate with deadlocked application"
+                               userInfo:nil]
+         raise];
+    }
+}
+
+@end
+
+@interface FBXCTestCaseImplementationFailureHoldingProxy ()
+@property (nonatomic, strong) _XCTestCaseImplementation *internalImplementation;
+@end
+
+@implementation FBXCTestCaseImplementationFailureHoldingProxy
+
++ (instancetype)proxyWithXCTestCaseImplementation:(_XCTestCaseImplementation *)internalImplementation
+{
+    FBXCTestCaseImplementationFailureHoldingProxy *proxy = [super alloc];
+    proxy.internalImplementation = internalImplementation;
+    return proxy;
+}
+
+- (id)forwardingTargetForSelector:(SEL)aSelector
+{
+    return self.internalImplementation;
+}
+
+// This will prevent test from quiting on app crash or any other test failure
+- (BOOL)shouldHaltWhenReceivesControl
+{
+    return NO;
+}
+
+@end

--- a/DeviceAgent/TestRunner.m
+++ b/DeviceAgent/TestRunner.m
@@ -1,8 +1,8 @@
 
 #import "CBXCUITestServer.h"
-#import <XCTest/XCTest.h>
+#import "FBFailureProofTestCase.h"
 
-@interface TestRunner : XCTestCase
+@interface TestRunner : FBFailureProofTestCase
 
 @end
 

--- a/Server/XCTest/_XCTestCaseImplementation.h
+++ b/Server/XCTest/_XCTestCaseImplementation.h
@@ -6,7 +6,7 @@
 
 @class NSArray, NSInvocation, NSMutableArray, NSMutableDictionary, NSMutableSet, NSString, XCTestCaseRun, XCTestContext;
 
-#import <XCTWebDriverAgentLib/CDStructures.h>
+#import "CDStructures.h"
 
 @interface _XCTestCaseImplementation : NSObject
 {


### PR DESCRIPTION
**FORCE PUSHED** Mon Sep 7 16:40 CET
### Motivation

This has been helpful while testing the automatic handling of SpringBoard alerts.

Catch exceptions when querying (#146) has not been working and this helped me figure out that it is the AXServer that is crashing/stopping.
