### PR TITLE
Server: resolve application before entering text

### DIFF
--- a/Server/AutomationActions/Gestures/EnterText.m
+++ b/Server/AutomationActions/Gestures/EnterText.m
@@ -23,7 +23,7 @@
     if (![gestureConfig has:CBX_STRING_KEY]) {
         @throw [InvalidArgumentException withFormat:@"Missing required key 'string'"];
     }
-    
+
     NSString *string = gestureConfig[CBX_STRING_KEY];
 
 // Original implementation - not working on iOS 10 physical devices
@@ -40,8 +40,13 @@
 
     // This is working on iOS 9 - 10 sims and physical devices.
     XCUIApplication *application = [Application currentApplication];
+    if ([application lastSnapshot] == nil) {
+        [[application applicationQuery] elementBoundByIndex:0];
+        [application resolve];
+    }
+
     [application typeText:string];
-    
+
     completion(nil);
     return nil;
 }


### PR DESCRIPTION
### Motivation

Before #157 was merged, `[Application currentApplication] always checked to see if the last snapshot was nil.  When the last snapshot was nil, a query was made and the application was`resolve`d.

The call to `resolve` caused AXServer crashes in Gesture routes when asking for the device orientation:

```
 long long orientation = [[Application currentApplication]
                             longLongInterfaceOrientation];
```

I forgot that EnterText also calls `[Application currentApplication]`.

This PR restores the behavior of `POST /enter-text` to what it was before #157.
