### PR TITLE
Touch: increase touch duration by 0.01

### DIFF
--- a/Server/AutomationActions/Gestures/DoubleTap.m
+++ b/Server/AutomationActions/Gestures/DoubleTap.m
@@ -31,7 +31,11 @@
                              longLongInterfaceOrientation];
     CGPoint coordinate = coordinates[0].cgpoint;
 
-    float duration = [self duration];
+    // Increase the duration by a little to trigger long press gestures.
+    // For example, a recognizer with 1.0 minimum duration will not be
+    // triggered by a 1.0 duration, but it will be triggered by a 1.0.1
+    // duration.
+    float duration = [self duration] + 0.01;
     float offset = duration;
 
     TouchPath *first = [TouchPath withFirstTouchPoint:coordinate

--- a/Server/AutomationActions/Gestures/Touch.m
+++ b/Server/AutomationActions/Gestures/Touch.m
@@ -47,6 +47,10 @@
 
     CGPoint coordinate = coordinates[0].cgpoint;
 
+    // Increase the duration by a little to trigger long press gestures.
+    // For example, a recognizer with 1.0 minimum duration will not be
+    // triggered by a 1.0 duration, but it will be triggered by a 1.0.1
+    // duration.
     float duration = [self duration] + 0.01;
     float offset = duration;
 

--- a/Server/AutomationActions/Gestures/TwoFingerTap.m
+++ b/Server/AutomationActions/Gestures/TwoFingerTap.m
@@ -36,7 +36,11 @@
 
     CGPoint coordinate = coordinates[0].cgpoint;
 
-    float duration = [self duration];
+    // Increase the duration by a little to trigger long press gestures.
+    // For example, a recognizer with 1.0 minimum duration will not be
+    // triggered by a 1.0 duration, but it will be triggered by a 1.0.1
+    // duration.
+    float duration = [self duration] + 0.01;
     float offset = duration;
 
     // TODO Add argument for orientation of fingers.  At the moment we assume

--- a/cucumber/features/steps/touch.rb
+++ b/cucumber/features/steps/touch.rb
@@ -77,7 +77,7 @@ Then(/^I long press a little button for (a short|a long|enough) time$/) do |time
   elsif time == "a long"
     duration = 2.0
   elsif time == "enough"
-    duration = 1.1
+    duration = 1.0
   end
 
   long_press({marked: "long press"}, {duration: duration})
@@ -87,7 +87,7 @@ end
 When(/^the home button is on the (top|right|left|bottom), I can long press$/) do |position|
   clear_small_button_action_label
   rotate_and_expect(position)
-  long_press({marked: "long press"}, {duration: 1.1})
+  long_press({marked: "long press"}, {duration: 1.0})
   wait_for_gesture_text("long press", "small button action")
   clear_small_button_action_label
 end
@@ -124,7 +124,7 @@ end
 When(/^the home button is on the (top|right|left|bottom), I can two-finger long press$/) do |position|
   rotate_and_expect(position)
   touch({marked: "complex touches"}, {:num_fingers => 2,
-                                                :duration => 1.1})
+                                      :duration => 1.0})
   wait_for_gesture_text("two-finger long press", "complex touches")
   clear_complex_button_action_label
 end


### PR DESCRIPTION
**REBASED** Fri Oct 7 13:03
### Motivation

I am fixing up the CalSmokeApp.

```
Scenario:  Long press
  When I long press the left box for 1 second
  Then the gesture description changes to long press
  When I long press the right box for 2 seconds
  Then the gesture description changes to long press
```

These are flickering (sometimes passing and sometimes failing) on physical devices and simulators.  David has demonstrated that our 1.0 second DeviceAgent touch is sometimes not long enough to trigger a 1.0 second GestureRecognizer.  I think that this is what is causing my flickering tests.

Bumping the duration by 0.01 stabilized my tests.

David and Jon, please edit if I have misunderstood the discussion we had today in Slack.
### TODO
- [x] Does double tap need this increase
- [x] Does two finger tap need this increase
- [x] Do we need/want a LongPress route - this gesture would always have a 0.01 additional duration and we could remove the additional duration from /touch.  **ANSWER** For now, no.  We will live with the 0.0.1 duration.
- [x] ~~TestCloud testing~~ Not possible without a HUGE amount of overhead.  Will test later.
- [x] Local testing
