### PR TITLE
Remove exception handling when computing visibility attributes in JSONUtils 

### DIFF
--- a/Server/Utilities/JSONUtils.m
+++ b/Server/Utilities/JSONUtils.m
@@ -52,30 +52,14 @@ static NSDictionary *typeStringToElementType;
 }
 
 + (BOOL)elementHitable:(XCUIElement *)element {
-    BOOL hitable = NO;
-
+    // element is sometimes an XCElementSnapshot.
+    // For example, /tree generates snapshots.
+    // TODO: Should /tree include hitable information.
     if (![element respondsToSelector:@selector(isHittable)]) {
-        return hitable;
+        return NO;
+    } else {
+        return [element isHittable];
     }
-
-    @try {
-        hitable = [element isHittable];
-    } @catch (NSException *exception) {
-        NSLog(@"DeviceAgent caught an exception while calling isHitable on an element.");
-
-        NSLog(@"===  EXCEPTION ===");
-        NSLog(@"%@", exception);
-        NSLog(@"");
-
-        NSLog(@"=== STACK SYMBOLS === ");
-        NSLog(@"%@", [exception callStackSymbols]);
-        NSLog(@"");
-
-        NSLog(@"=== RUNTIME DETAILS ===");
-        NSLog(@"        element: %@", element);
-        NSLog(@"  element class: %@", [element class]);
-    }
-    return hitable;
 }
 
 


### PR DESCRIPTION
### Motivation

I have not seen an exception in a long time _and_ even if we catch an exception, the AX Server dies.
