### PR TITLE
Feature/improve plist patch

### DIFF
--- a/bin/patch-runner-info-plist.sh
+++ b/bin/patch-runner-info-plist.sh
@@ -99,10 +99,10 @@ function extract_identity {
     NAME=`echo ${DETAILS} | egrep -o "iPhone Developer: .*\)" |  tr -d '\n'`
     CLEAN_NAME=`echo $NAME | cut -d\( -f1 | sed -e 's/[[:space:]]*$//'`
     SHA=`xcrun security find-certificate -a -Z -c "${CLEAN_NAME}" \
-| grep "SHA-1" \
-| head -n1 \
-| cut -d: -f2 \
-| sed -e 's/^[[:space:]]*//'`
+      | grep "SHA-1" \
+      | head -n1 \
+      | cut -d: -f2 \
+      | sed -e 's/^[[:space:]]*//'`
     eval "$1=\"${SHA}\""
 }
 


### PR DESCRIPTION
Instead of using the certificate name for resigning, we should use the sha-1 hash. There is no ambiguity if we do that. 

CC: @jmoody @acroos 
