### PR TITLE
rm completion from threadutils runSync

### DIFF
--- a/Server/AutomationActions/Gestures/ClearText.m
+++ b/Server/AutomationActions/Gestures/ClearText.m
@@ -26,7 +26,8 @@
     }
     XCUIElement *el = results[0];
 
-    [ThreadUtils runSync:^(BOOL *setToTrueWhenDone, NSError *__autoreleasing *err) {
+    __block NSError *err;
+    [ThreadUtils runSync:^(BOOL *setToTrueWhenDone) {
         NSString *string = el.value;
         NSMutableString *delString = [NSMutableString new];
         for (int i = 0; i < string.length; i++) {
@@ -37,11 +38,12 @@
         [[Testmanagerd get] _XCT_sendString:string
                            maximumFrequency:CBX_DEFAULT_SEND_STRING_FREQUENCY
                                  completion:^(NSError *e) {
-                                     *err = e;
+                                     err = e;
                                      *setToTrueWhenDone = YES;
                                  }];
-    } completion:completion];
+    }];
     
+    completion(err);
     return nil;
 }
 

--- a/Server/AutomationActions/Gestures/ClearTextIn.m
+++ b/Server/AutomationActions/Gestures/ClearTextIn.m
@@ -22,7 +22,8 @@
                                 userInfo:[JSONUtils elementToJSON:el]];
     }
 
-    [ThreadUtils runSync:^(BOOL *setToTrueWhenDone, NSError *__autoreleasing *err) {
+    __block NSError *err;
+    [ThreadUtils runSync:^(BOOL *setToTrueWhenDone) {
         NSString *string = el.value;
         NSMutableString *delString = [NSMutableString new];
         for (int i = 0; i < string.length; i++) {
@@ -33,11 +34,12 @@
         [[Testmanagerd get] _XCT_sendString:string
                            maximumFrequency:CBX_DEFAULT_SEND_STRING_FREQUENCY
                                  completion:^(NSError *e) {
-                                     *err = e;
+                                     err = e;
                                      *setToTrueWhenDone = YES;
                                  }];
-    } completion:completion];
+    }];
     
+    completion(err);
     return nil;
 }
 

--- a/Server/AutomationActions/Gestures/EnterTextIn.m
+++ b/Server/AutomationActions/Gestures/EnterTextIn.m
@@ -25,23 +25,23 @@
     }
     
     Touch *touch = [Touch withGestureConfiguration:gestureConfig query:query];
-
+    __block NSError *err;
     [touch execute:^(NSError *e) {
         if (e) {
             completion(e);
         } else {
-            [ThreadUtils runSync:^(BOOL *setToTrueWhenDone, NSError *__autoreleasing *err) {
+            [ThreadUtils runSync:^(BOOL *setToTrueWhenDone) {
                 [[Testmanagerd get] _XCT_sendString:string
                                          maximumFrequency:CBX_DEFAULT_SEND_STRING_FREQUENCY
                                          completion:^(NSError *e) {
                     if (e) @throw [CBXException withMessage:@"Error performing gesture"];
-                    *err = e;
+                    err = e;
                     *setToTrueWhenDone = YES;
                 }];
-            } completion:completion];
+            }];
         }
     }];
-    
+    completion(err);
     return touch;
 }
 @end

--- a/Server/AutomationActions/Gestures/Gesture.m
+++ b/Server/AutomationActions/Gestures/Gesture.m
@@ -81,7 +81,8 @@
     }
     
     //Testmanagerd calls are async, but the http server is sync so we need to synchronize it.
-    [ThreadUtils runSync:^(BOOL *setToTrueWhenDone, NSError *__autoreleasing *err) {
+    __block NSError *err;
+    [ThreadUtils runSync:^(BOOL *setToTrueWhenDone) {
 
         if ([[XCTestDriver sharedTestDriver] daemonProtocolVersion] ) {
             NSLog(@"WARNING: Testing on daemonProtocolVersion %@", @([[XCTestDriver sharedTestDriver] daemonProtocolVersion]));
@@ -89,10 +90,11 @@
         CBXTouchEvent *event = [self cbxEventWithCoordinates:coords];
         [[Testmanagerd get] _XCT_synthesizeEvent:event.event
                                       completion:^(NSError *e) {
-                                          *err = e;
+                                          err = e;
                                           *setToTrueWhenDone = YES;
                                       }];
-    } completion:completion];
+    }];
+    completion(err);
 }
 
 @end

--- a/Server/CBXTypedefs.h
+++ b/Server/CBXTypedefs.h
@@ -16,11 +16,8 @@ typedef void (^Block)(void);
 /**
     A block intended to be used in an async context. 
     The BOOL * param should be set to YES when the async 
-    functionality is complete (or whenever it's "done enough"). 
-    
-    If any errors should arise, you can indicate them with
-    `*err = myErr`
+    functionality is complete (or whenever it's "done enough").
  */
-typedef void (^AsyncBlock)(BOOL *setToTrueWhenDone, NSError **err);
+typedef void (^AsyncBlock)(BOOL *setToTrueWhenDone);
 
 #endif /* CBXTypedefs_h */

--- a/Server/Utilities/ThreadUtils.h
+++ b/Server/Utilities/ThreadUtils.h
@@ -6,16 +6,13 @@
 Utility methods for abstracting less obvious thread-related functionality.
  */
 @interface ThreadUtils : NSObject
-NS_ASSUME_NONNULL_BEGIN
 /**
  Run an async block to completion and then synchronously execute a completion block. 
  The completion block will be executed on the same thread as the calling stack frame. 
  
  @param block AsyncBlock to wait on
- @param completion Block which executes after waiting for the async block to complete.
  @warning If you don't ever flag the AsyncBlock as complete via it's `BOOL *setToTrueWhenDone`, 
  the completion block will never execute.
  */
-+ (void)runSync:(AsyncBlock)block completion:(CompletionBlock)completion;
-NS_ASSUME_NONNULL_END
++ (void)runSync:(AsyncBlock)block;
 @end

--- a/Server/Utilities/ThreadUtils.m
+++ b/Server/Utilities/ThreadUtils.m
@@ -3,15 +3,13 @@
 #import "CBXConstants.h"
 
 @implementation ThreadUtils
-+ (void)runSync:(AsyncBlock)block completion:(CompletionBlock)completion {
++ (void)runSync:(AsyncBlock)block {
     BOOL done = NO;
-    __block NSError *err;
-    block(&done, &err);
+    
+    block(&done);
     
     while(!done){
         [[NSRunLoop currentRunLoop] runUntilDate:[NSDate dateWithTimeIntervalSinceNow:CBX_RUNLOOP_INTERVAL]];
     }
-    
-    completion(err);
 }
 @end


### PR DESCRIPTION
## Motivation

There was a method:

``` objc
+ (void)runSync:(AsyncBlock)block completion:(CompletionBlock)completion;
```

Which is actually more confusing than it needs to be. Typically completion blocks imply async exectution. The `AsyncBlock` will run completely synchronously, so there's no need for 'completion' : whatever code comes after the invocation will be run synchronously after the invocation completes. 

E.g. 

``` objc

[SomeCode runA];
[ThreadUtils runSync:^(BOOL *setToTrueWhenDone, NSError *__autoreleasing *err) {
    *setToTrueWhenDone = YES;
   completion(err);
}];
[SomeCode runB];
```

The order of execution will be `runA`, `completion()`, `runB`, so it can be simplified by just moving the code outside of the `ThreadUtils` block. 

CC: @jmoody @acroos 
