### PR TITLE
Call enterText: on first responder

### DIFF
--- a/Server/AutomationActions/Gestures/EnterText.m
+++ b/Server/AutomationActions/Gestures/EnterText.m
@@ -5,6 +5,10 @@
 #import "EnterText.h"
 #import "Application.h"
 
+@interface EnterText ()
+
+@end
+
 @implementation EnterText
 
 + (NSString *)name { return @"enter_text"; }
@@ -24,31 +28,50 @@
         @throw [InvalidArgumentException withFormat:@"Missing required key 'string'"];
     }
 
-    NSString *string = gestureConfig[CBX_STRING_KEY];
+    @synchronized (self) {
 
-// Original implementation - not working on iOS 10 physical devices
-// https://xamarin.atlassian.net/browse/TCFW-333
-//
-//    [ThreadUtils runSync:^(BOOL *setToTrueWhenDone, NSError *__autoreleasing *err) {
-//        [[Testmanagerd get] _XCT_sendString:string
-//         maximumFrequency:CBX_DEFAULT_SEND_STRING_FREQUENCY
-//                                 completion:^(NSError *e) {
-//            *err = e;
-//            *setToTrueWhenDone = YES;
-//        }];
-//    } completion:completion];
+        NSString *string = gestureConfig[CBX_STRING_KEY];
 
-    // This is working on iOS 9 - 10 sims and physical devices.
-    XCUIApplication *application = [Application currentApplication];
-    if ([application lastSnapshot] == nil) {
-        [[application applicationQuery] elementBoundByIndex:0];
-        [application resolve];
+        XCUIApplication *application = [Application currentApplication];
+        NSPredicate *predicate = [NSPredicate predicateWithFormat:@"%K = %@",
+                                  @"hasKeyboardFocus",
+                                  @(YES)];
+
+        XCUIElement *firstResponder = nil;
+
+        // This is an optimization.  Querying all elements is for the one with keyboard focus
+        // can be prohibitively expensive (tens of seconds).
+        NSArray<NSNumber *> *types = @[@(XCUIElementTypeTextField),
+                                       @(XCUIElementTypeTextView),
+                                       @(XCUIElementTypeSecureTextField),
+                                       @(XCUIElementTypeOther)];
+        for (NSNumber *number in types) {
+            NSUInteger type = [number unsignedIntegerValue];
+            XCUIElementQuery *firstResponderQuery = [application descendantsMatchingType:type];
+            XCUIElementQuery *matching = [firstResponderQuery matchingPredicate:predicate];
+            NSArray <XCUIElement *> *elements = [matching allElementsBoundByIndex];
+            if ([elements count] == 1) {
+                firstResponder = elements[0];
+                NSLog(@"Element with keyboard focus has type %@", [JSONUtils stringForElementType:type]);
+                break;
+            }
+        }
+
+        if (!firstResponder) {
+            NSLog(@"Could not find an element with keyboard focus; will use the XCUIApplication#typeText");
+
+            // This seems to work in most cases.  However, we've observed problems:
+            // * typing text is very slow (characters per hour)
+            // * this error message is emitted:
+            //   Xcode UI Testing fails to type text: Neither element nor any descendant has keyboard focus
+            firstResponder = application;
+        }
+
+        [firstResponder typeText:string];
+
+        completion(nil);
+        return nil;
     }
-
-    [application typeText:string];
-
-    completion(nil);
-    return nil;
 }
 
 @end

--- a/Server/Utilities/JSONUtils.m
+++ b/Server/Utilities/JSONUtils.m
@@ -34,7 +34,7 @@ static NSDictionary *unhitablePoint;
     json[CBX_ENABLED_KEY] = @(snapshot.wdEnabled);
     json[CBX_TEST_ID] = [Application cacheElement:(XCUIElement *)snapshot];
 
-    NSDictionary *visibilityInfo;
+    NSDictionary *visibilityInfo = @{};
     if ([[snapshot class] isSubclassOfClass:[XCElementSnapshot class]]) {
         visibilityInfo = [JSONUtils visibilityInfoWithSnapshot:(XCElementSnapshot *)snapshot];
     } else if ([[snapshot class] isSubclassOfClass:[XCUIElement class]]) {


### PR DESCRIPTION
**FORCE PUSHED** Wed Nov 23 15:17 CET

### Motivation

Alternative to `XCT_sendString`.

### Tests

- [x] iOS Simulators iOS 9 - iOS 10.2 against Xcode 8.0 - 8.2 beta 2 on Sierra and El Cap.
- [x] iOS 9.3.2 iPhone 5s
- [x] iOS 9.3.3 iPad Mini Retina
- [x] iOS 9.3.5 iPhone 5c
- [x] iOS 10.1.1 iPad Mini Retina
- [x] iOS 10.1.1 iPhone 6s
- [x] iOS 10.2 beta 2 iPhone 6

