### PR TITLE
DeviceAgent: generate and distribute a dSYM

### DIFF
--- a/DeviceAgent.xcodeproj/project.pbxproj
+++ b/DeviceAgent.xcodeproj/project.pbxproj
@@ -2933,7 +2933,7 @@
 				CLANG_ENABLE_MODULES = NO;
 				CODE_SIGN_IDENTITY = "iPhone Developer: Karl Krukow (YTTN6Y2QS9)";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer: Karl Krukow (YTTN6Y2QS9)";
-				DEBUG_INFORMATION_FORMAT = dwarf;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DEVELOPMENT_TEAM = FYD86LA7RE;
 				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = DeviceAgent/Info.plist;
@@ -2955,7 +2955,7 @@
 				CLANG_ENABLE_MODULES = NO;
 				CODE_SIGN_IDENTITY = "iPhone Developer: Karl Krukow (YTTN6Y2QS9)";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer: Karl Krukow (YTTN6Y2QS9)";
-				DEBUG_INFORMATION_FORMAT = dwarf;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DEVELOPMENT_TEAM = FYD86LA7RE;
 				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = DeviceAgent/Info.plist;


### PR DESCRIPTION
### Motivation

Progress on:

* DeviceAgent is crashing on server start [TCFW-866](https://jira.xamarin.com/browse/TCFW-867)

Completes:

* DeviceAgent builds should generate a dSYM bundle and the bundle should be distributed [TCFW-867](https://jira.xamarin.com/browse/TCFW-867)