### PR TITLE
Replace NSRunLoop runUntilDate: with CFRunLoopRunInMode to avoid unreliable NSDate behaviors

### DIFF
--- a/Server/Application/SpringBoard.m
+++ b/Server/Application/SpringBoard.m
@@ -275,9 +275,8 @@ typedef enum : NSUInteger {
             // environments e.g. CI, XTC, Simulators, etc.
             //
             // We prefer stability over speed.
-            NSTimeInterval interval = 1.0;
-            NSDate *until = [[NSDate date] dateByAddingTimeInterval:interval];
-            [[NSRunLoop mainRunLoop] runUntilDate:until];
+            CFTimeInterval interval = 1.0;
+            CFRunLoopRunInMode(kCFRunLoopDefaultMode, interval, false);
         }
         return success;
     }

--- a/Server/CBXCUITestServer.m
+++ b/Server/CBXCUITestServer.m
@@ -86,14 +86,9 @@ static NSString *serverName = @"CalabashXCUITestServer";
           [UIDevice currentDevice].wifiIPAddress,
           [self.server port]);
 
-    NSTimeInterval interval = 0.1;
     while ([self.server isRunning] && !self.isFinishedTesting) {
 
-        // If we are worried about alloc'ing NSDate objects, it might be
-        // possible to replace with:
-        // CFRunLoopRunInMode(kCFRunLoopDefaultMode, timeout_, false);
-        NSDate *until = [[NSDate date] dateByAddingTimeInterval:interval];
-        [[NSRunLoop mainRunLoop] runUntilDate:until];
+         CFRunLoopRunInMode(kCFRunLoopDefaultMode, CBX_RUNLOOP_INTERVAL, false);
 
         // Turning this behavior off because it has some unpleasant side effects.
         //

--- a/Server/CBXConstants.h
+++ b/Server/CBXConstants.h
@@ -90,10 +90,10 @@ static NSUInteger const HTTP_STATUS_CODE_SERVER_ERROR = 500;
 static int const CBX_MIN_NUM_FINGERS = 1;
 static int const CBX_MAX_NUM_FINGERS = 5;
 
+static CFTimeInterval const CBX_RUNLOOP_INTERVAL = 0.1; // seconds
 static float const CBX_MIN_ROTATION_START = 0;      //degrees
 static float const CBX_MAX_ROTATION_START = 360;    //degrees
 static float const CBX_MIN_LONG_PRESS_DURATION = 0.5; //determined through trial and error w/UILongPressGestureRecognizer
-static float const CBX_RUNLOOP_INTERVAL = 0.1;
 static float const CBX_DEFAULT_DURATION = 0.1;
 static BOOL const CBX_DEFAULT_ALLOW_INERTIA_IN_DRAG = YES;
 static float const CBX_DOUBLE_TAP_PAUSE_DURATION = 0.1;

--- a/Server/Utilities/ThreadUtils.m
+++ b/Server/Utilities/ThreadUtils.m
@@ -9,7 +9,7 @@
     block(&done);
     
     while(!done){
-        [[NSRunLoop currentRunLoop] runUntilDate:[NSDate dateWithTimeIntervalSinceNow:CBX_RUNLOOP_INTERVAL]];
+        CFRunLoopRunInMode(kCFRunLoopDefaultMode, CBX_RUNLOOP_INTERVAL, false);
     }
 }
 @end


### PR DESCRIPTION
Removes the use of [NSRunLoop runUntil], which in turn gets rid of more uses of NSDate, which is unreliable to use for timeout-like purposes.  