### PR TITLE
SpringBoard: ask UIApplication for SpringBoard alert before making an expensive XCUITest query

### DIFF
--- a/Server/Application/SpringBoard.m
+++ b/Server/Application/SpringBoard.m
@@ -89,8 +89,9 @@ typedef enum : NSUInteger {
     @synchronized (self) {
         XCUIElement *alert = nil;
 
+        [self _waitForQuiescence];
+
         if([self UIApplication_isSpringBoardShowingAnAlert]) {
-            [self _waitForQuiescence];
 
             XCUIElementQuery *query = [self descendantsMatchingType:XCUIElementTypeAlert];
             NSArray <XCUIElement *> *elements = [query allElementsBoundByIndex];


### PR DESCRIPTION
### Motivation

`POST /dismiss-springboard-alerts` is expensive - the XCUITest query takes a long time.  The clients and DeviceAgent both make many calls to dismiss SpringBoard alerts.

We can ask UIApplication if there is a SpringBoard alert showing and only then perform the expensive XCUITest query.

Completes:

* Speed up SpringBoard alert detection using UIApplication private method [TCFW-897](https://jira.xamarin.com/browse/TCFW-897)

