### PR TITLE
Dismiss SpringBoard alerts by touching alert buttons with coordinates

### DIFF
--- a/Server/Application/SpringBoard.m
+++ b/Server/Application/SpringBoard.m
@@ -304,6 +304,10 @@ typedef enum : NSUInteger {
             }
         }];
 
+        // Let the main RunLoop progress before executing more queries or
+        // gestures.  It is possible that a failed touch will succeed on the
+        // next pass.
+        //
         // There is one alert workflow that is very problematic:
         //
         // PhotoRoll
@@ -321,7 +325,7 @@ typedef enum : NSUInteger {
         // of the Cancel touch.  Sleeping after the dismiss definitely
         // reduced the frequency of crashes - they still happened.
         //
-        // The AUT crash was caused by IImagePickerViewController which has a
+        // The AUT crash was caused by UIImagePickerViewController which has a
         // history of crashing in situations like this.
         //
         // After days device and simulator testing, I settled on 1.0 second.
@@ -335,7 +339,9 @@ typedef enum : NSUInteger {
         // We prefer stability over speed.
         CFTimeInterval interval = 1.0;
         CFRunLoopRunInMode(kCFRunLoopDefaultMode, interval, false);
-    }
+
+        return success;
+   }
 }
 
 - (CGPoint)hitPointForAlertButton:(XCUIElement *)alertButton {


### PR DESCRIPTION
### Motivation

DeviceAgent 1.0.4 used `[XCUIElement tap]` to dismiss SpringBoard alerts.

This allowed DeviceAgent to dismiss alerts in any orientation, but it appears to have made the DeviceAgent environment unstable on the XTC.  Before 1.0.4, the Permissions app nightly runs looked very healthy.  During the 1.0.4 testing, I did notice stalled jobs but was not able to pin the blame directly on `[XCUIElement tap]`.  I did a bunch of post release testing and noticed that the Permissions tests were very unstable in 1.0.4.

* [Permission app on the XTC](https://testcloud.xamarin.com/app/946807a0-8a14-4285-9f82-31fe8c22af40/)

Notice that before Dec 13th the test runs look good - most of those runs are kicked off by nightly CI.  On December 13, you can see a bunch of failed tests - those are my post-release stress tests.  The December 19 nightlies are green - those are against 1.0.3.  DeviceAgent 1.0.4 was put into production December 19 in the afternoon CET.

### Tests

DeviceAgent SHA: `8d1696673960f21bcd45c25857226ccb443258aa`

- [x] Local iOS 10 simulator / Xcode 8.2
- [x] Local iOS 9 - 10 physical devices - In progress
- [x] XTC test runs
  - [x] [upside down](https://testcloud.xamarin.com/test/permissions_67525898-f8d3-41f6-a367-b3154bb5d665/)
  - [x] [home button left](https://testcloud.xamarin.com/app/946807a0-8a14-4285-9f82-31fe8c22af40/left)
  - [x] [home button right](https://testcloud.xamarin.com/test/permissions_21e1f0f6-b4d6-45dd-85af-463f5dbd8151/)
  - [x] [portrait](https://testcloud.xamarin.com/test/permissions_51389d64-2ed7-433f-9f39-d31ae526111f/)
  - [x] [portrait](https://testcloud.xamarin.com/test/permissions_cb66e5f2-b919-4a46-a0bb-adc3059d443b/)

### Notes

Includes **SpringBoard: ask UIApplication for SpringBoard alert before making an expensive XCUITest query** #190

Initially, I implemented the hit point calculation and translation in JSONUtils.  This seemed to make sense at first.  However, it turns out that only SpringBoard requires hit points to be translated - view in the AUT never need hit point translation.

There are also some subtle differences between XCUIElement and XCSnapshotElement hit point computations which makes a generic solution tricky.

In a subsequent pull request, I will update JSONUtils to fix several problems.  Notably, there will be a fix for:

* GET /tree can crash on call to `hitpoint` in JSONUtils [TFCW-878](https://jira.xamarin.com/browse/TCFW-878)
