### PR TITLE
Add SpringBoard alert localizations for nl_BE and sv to 1.0.5

### DIFF
--- a/Server/Utilities/SpringboardAlerts.m
+++ b/Server/Utilities/SpringboardAlerts.m
@@ -21,6 +21,7 @@ static SpringBoardAlert *alert(NSString *buttonTitle, BOOL shouldAccept, NSStrin
 - (NSArray<SpringBoardAlert *> *)DanishAlerts;
 - (NSArray<SpringBoardAlert *> *)DutchAlerts;
 - (NSArray<SpringBoardAlert *> *)DutchAlerts_BE;
+- (NSArray<SpringBoardAlert *> *)SwedishAlerts;
 - (NSArray<SpringBoardAlert *> *)GermanAlerts;
 - (NSArray<SpringBoardAlert *> *)EUSpanishAlerts;
 - (NSArray<SpringBoardAlert *> *)ES419SpanishAlerts;
@@ -46,6 +47,7 @@ static SpringBoardAlert *alert(NSString *buttonTitle, BOOL shouldAccept, NSStrin
                                             [self DanishAlerts],
                                             [self DutchAlerts],
                                             [self DutchAlerts_BE],
+                                            [self SwedishAlerts],
                                             [self EUSpanishAlerts],
                                             [self ES419SpanishAlerts],
                                             [self GermanAlerts],
@@ -160,7 +162,24 @@ static SpringBoardAlert *alert(NSString *buttonTitle, BOOL shouldAccept, NSStrin
              alert(@"OK", YES, @"wil toegang tot Twitter-accounts"),
              alert(@"OK", YES, @"wil toegang tot de microfoon"),
              alert(@"OK", YES, @"wil toegang tot je bewegings- en fitnessactiviteit"),
-             alert(@"OK", YES, @"wil toegang tot de camera"),
+             alert(@"OK", YES, @"wil toegang tot de camera")
+             ];
+}
+
+- (NSArray<SpringBoardAlert *> *)SwedishAlerts {
+    return @[
+             alert(@"Tillåt", YES, @"att se din platsinfo när du använder appen"),
+             alert(@"Tillåt", YES, @"även ser din platsinfo när du inte använder appen"),
+             alert(@"Tillåt", YES, @"att se din platsinfo även när du inte använder appen"),
+             alert(@"OK", YES, @"begär åtkomst till dina kontakter"),
+             alert(@"OK", YES, @"begär åtkomst till din kalender"),
+             alert(@"OK", YES, @"begär åtkomst till dina påminnelser"),
+             alert(@"OK", YES, @"begär åtkomst till dina bilder"),
+             alert(@"OK", YES, @"vill komma åt dina Twitter-konton"),
+             alert(@"OK", YES, @"begär åtkomst till mikrofonen"),
+             alert(@"OK", YES, @"begär åtkomst till din rörelse- och träningsaktivitet"),
+             alert(@"OK", YES, @"begär åtkomst till kameran"),
+             alert(@"Tillåt", YES, @"vill skicka notiser till dig")
              ];
 }
 - (NSArray<SpringBoardAlert *> *)GermanAlerts {


### PR DESCRIPTION
### Motivation

* Swedish localization for privacy alerts [TCFW-947](https://jira.xamarin.com/browse/TCFW-947)
* Add nl_BE localizations to Dutch privacy alerts [TFCW-922](https://jira.xamarin.com/browse/TCFW-922)

### TODO

- [x] Run on iOS 9 physical device
- [x] Run on iOS 9 simulator

