### PR TITLE
SpringBoard#queryForAlert: skip _waitForQuiescence check

### DIFF
--- a/Server/Application/SpringBoard.m
+++ b/Server/Application/SpringBoard.m
@@ -93,8 +93,6 @@ typedef enum : NSUInteger {
     @synchronized (self) {
         XCUIElement *alert = nil;
 
-        [self _waitForQuiescence];
-
         if([self UIApplication_isSpringBoardShowingAnAlert]) {
 
             XCUIElementQuery *query = [self descendantsMatchingType:XCUIElementTypeAlert];


### PR DESCRIPTION
### Motivation

We demonstrated that there was a problem with DeviceAgent 1.0.5 in **iOS: update to DeviceAgent 1.0.5** [#346](https://github.com/xamarin/test-cloud-execution-pipeline/pull/346).

I believe the problem is the call to `XCUIApplication#_waitForQuiescence` during the SpringBoard alert check.

### Tests

All tests are performed on iOS 10 devices.

* **DeviceAgent SHA:** 87c0333d165301c018779c35abb418ac9e6ac96d
* **Pipeline:** pipeline:update-to-DeviceAgent-1.0.5_better_logging

#### Calabash

- iPhoneOnlyApp - 8 Devices
   - [**PASSED**](https://testcloud.xamarin.com/test/iphoneonly_4897ab11-d8e7-408e-aa72-1cdbacf5d0e7/)
   - [**PASSED**](https://testcloud.xamarin.com/test/iphoneonly_f5af53a5-3c15-45dd-bc5b-579831ba50ae/)

- Permissions - 24  Devices 
  - [**PASSED**](https://testcloud.xamarin.com/test/permissions_170e87dc-7add-442a-b7c4-6593927d4437/) -  [1 failure Location Services not enabled](https://github.com/xamarin/test-cloud-operations/issues/4256) and [1 stalled device](https://github.com/xamarin/test-cloud-operations/issues/4262)
  - [**PASSED**](https://testcloud.xamarin.com/test/permissions_24770f77-7fdb-4369-b46a-be81821f7a94/)


- CalSmokeApp - there are 2 Scenarios that fail intentionally
   - Feature: One Bug
       - [8 Devices **PASSED**](https://testcloud.xamarin.com/test/calsmoke-cal_5b4c9c24-475e-4d43-9626-5a99f52f5785/) 
       - [24 Devices **PASSED**](https://testcloud.xamarin.com/test/calsmoke-cal_bc32876b-d104-4bdd-9e4a-a14a5f69ce99/)
   - All Features
       - [24 Devices **FAILED**](https://testcloud.xamarin.com/test/calsmoke-cal_c190094b-8712-45c6-95c6-9be5e506eb9f/) - [1 unexplained error](https://testcloud.xamarin.com/test/calsmoke-cal_c190094b-8712-45c6-95c6-9be5e506eb9f/?step=8_0_9&device=apple_iphone_se-10.2.1&tab=stacktrace) This was not a fatal error.  DeviceAgent continued to run and execute the remaining Scenarios.  This is probably a client error in calabash-ios.
       - [24 Devices **PASSED**](https://testcloud.xamarin.com/test/calsmoke-cal_7b9dd18a-42de-4f11-85ac-91a8282286e8/)
       - [24 Devices **PASSED**](https://testcloud.xamarin.com/test/calsmoke-cal_794c0b5b-a41b-4591-b236-a9226d508f0c/)

#### UITest

Tested against 24 iOS 10 Devices.
- [PASSED](https://testcloud.xamarin.com/test/xtciossampleproject_63dc2113-5086-48a4-9349-43d162277f31/)
- [PASSED (1 still running)](https://testcloud.xamarin.com/test/com-microsoft-xtc-frameworks-uitest-int-test_829dff1a-4bb0-45af-9133-bf87e977e7e0/)

One device error was present in the run:
https://github.com/xamarin/test-cloud-operations/issues/4265
