### PR TITLE
Server: disable screenshots on server start

### DIFF
--- a/Server/CBXCUITestServer.m
+++ b/Server/CBXCUITestServer.m
@@ -89,6 +89,9 @@ static NSString *serverName = @"CalabashXCUITestServer";
           [UIDevice currentDevice].wifiIPAddress,
           [self.server port]);
 
+    DDLogDebug(@"Disabling screenshots in NSUserDefaults");
+    [[NSUserDefaults standardUserDefaults] setBool:YES forKey:@"DisableScreenshots"];
+
     while ([self.server isRunning] && !self.isFinishedTesting) {
 
          CFRunLoopRunInMode(kCFRunLoopDefaultMode, CBX_RUNLOOP_INTERVAL, false);


### PR DESCRIPTION
### Motivation

XCUITest takes a lot screenshots.  Surprise!

The hypothesis is that disabling screenshots makes overlapping gestures a lot less likely to occur.

This does not fix the `Timed out waiting for key event` bug on simulators or physical devices.

### Tests

- [x] Simulators El Cap
- [x] Simulators Sierra
- [x] Physical Devices
- [x] Test Cloud : [**PASSED**](https://testcloud.xamarin.com/test/calsmoke-cal_208824a7-d305-4bdf-9378-1238c65104f3/) - the 2 failing Scenarios are expected to fail.


DeviceAgent SHA: 6361f06e4b05cd7cf8d62829d31544680f046851
