### PR TITLE
DeviceAgent.xctest: change bundle identifier to sh.calaba.DeviceAgent

### DIFF
--- a/DeviceAgent.xcodeproj/project.pbxproj
+++ b/DeviceAgent.xcodeproj/project.pbxproj
@@ -3325,7 +3325,7 @@
 				INFOPLIST_PREPROCESS = NO;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				ONLY_ACTIVE_ARCH = NO;
-				PRODUCT_BUNDLE_IDENTIFIER = "com.apple.test.DeviceAgent-Runner";
+				PRODUCT_BUNDLE_IDENTIFIER = sh.calaba.DeviceAgent;
 				PRODUCT_NAME = DeviceAgent;
 				PROVISIONING_PROFILE = "fb4b8ed8-fb70-4b90-8f51-33e10f8f670e";
 				PROVISIONING_PROFILE_SPECIFIER = DeviceAgent;
@@ -3346,7 +3346,7 @@
 				INFOPLIST_PREFIX_HEADER = "";
 				INFOPLIST_PREPROCESS = NO;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = "com.apple.test.DeviceAgent-Runner";
+				PRODUCT_BUNDLE_IDENTIFIER = sh.calaba.DeviceAgent;
 				PRODUCT_NAME = DeviceAgent;
 				PROVISIONING_PROFILE = "fb4b8ed8-fb70-4b90-8f51-33e10f8f670e";
 				PROVISIONING_PROFILE_SPECIFIER = DeviceAgent;


### PR DESCRIPTION
### Motivation

When Xcode builds a test runner and test bundle (.xctest), the bundle identifiers are:

* test runner => com.apple.test.\<Product Name\>-Runner
* test bundle => com.example.\<Product Name\>

This PR changes the DeviceAgent.xctest bundle identifier from `com.apple.test.DeviceAgent` to `sh.calaba.DeviceAgent`.

I discovered this inconsistency while exploring Xcode 8.3 support.

### Notes

No changes are necessary on the XTC.

### Tests

- [x] [Test Cloud](https://testcloud.xamarin.com/test/iphoneonly_70de7705-58f5-44cc-ae13-e16c29fb3380/)
- [x] Local simulator
- [x] Local device
