### PR TITLE
SpringBoard: add French 'no SIM card installed' localization

### DIFF
--- a/Server/Utilities/SpringBoardAlerts.m
+++ b/Server/Utilities/SpringBoardAlerts.m
@@ -249,7 +249,8 @@ static SpringBoardAlert *alert(NSString *buttonTitle, BOOL shouldAccept, NSStrin
              alert(@"OK", YES, @"souhaite accéder à l’appareil photo"),
              alert(@"OK", YES, @"souhaite accéder aux comptes Twitter"),
              alert(@"OK", YES, @"souhaite accéder au micro"),
-             alert(@"Ouvrir", YES, @"Ouvrir dans")
+             alert(@"Ouvrir", YES, @"Ouvrir dans"),
+             alert(@"OK", YES, @"Aucune carte SIM")
              ];
 }
 


### PR DESCRIPTION
### Motivation

* "NO sim card installed" alert in french cannot be dismissed [#1251](https://github.com/calabash/calabash-ios/issues/1251)

