### PR TITLE
XCUIApplication#interfaceOrientation returns UIInterfaceOrientation enum

### DIFF
--- a/Server/AutomationActions/Gestures/DoubleTap.m
+++ b/Server/AutomationActions/Gestures/DoubleTap.m
@@ -27,8 +27,9 @@
 
 - (CBXTouchEvent *)cbxEventWithCoordinates:(NSArray <Coordinate *> *)coordinates {
 
-    long long orientation = [[Application currentApplication]
-                             longLongInterfaceOrientation];
+    UIInterfaceOrientation orientation = [[Application currentApplication]
+                                          interfaceOrientation];
+
     CGPoint coordinate = coordinates[0].cgpoint;
 
     // Increase the duration by a little to trigger long press gestures.

--- a/Server/AutomationActions/Gestures/Drag.m
+++ b/Server/AutomationActions/Gestures/Drag.m
@@ -36,8 +36,8 @@
 - (CBXTouchEvent *)cbxEventWithCoordinates:(NSArray<Coordinate *> *)coordinates {
     CBXTouchEvent *event = [CBXTouchEvent new];
 
-    long long orientation = [[Application currentApplication]
-                             longLongInterfaceOrientation];
+    UIInterfaceOrientation orientation = [[Application currentApplication]
+                                          interfaceOrientation];
     
     for (int fingerIndex = 0; fingerIndex < [self numFingers]; fingerIndex++ ) {
         CGPoint fingerOffset = [GeometryUtils fingerOffsetForFingerIndex:fingerIndex];

--- a/Server/AutomationActions/Gestures/EventSynthesis/CBXTouchEvent.m
+++ b/Server/AutomationActions/Gestures/EventSynthesis/CBXTouchEvent.m
@@ -5,9 +5,9 @@
 
 @property (nonatomic, strong) XCSynthesizedEventRecord *event;
 //@property (nonatomic, strong) XCTouchGesture *gesture;
-@property (nonatomic) long long orientation;
+@property (nonatomic) UIInterfaceOrientation orientation;
 
-+ (XCSynthesizedEventRecord *)eventRecordWithOrientation:(long long)orientation;
++ (XCSynthesizedEventRecord *)eventRecordWithOrientation:(UIInterfaceOrientation)orientation;
 
 @end
 
@@ -48,7 +48,7 @@
             self.event];
 }
 
-+ (XCSynthesizedEventRecord *)eventRecordWithOrientation:(long long)orientation {
++ (XCSynthesizedEventRecord *)eventRecordWithOrientation:(UIInterfaceOrientation)orientation {
     return [[XCSynthesizedEventRecord alloc]
             initWithName:@"CBXTouchEvent_XCSynthesizedEventRecord"
             interfaceOrientation:orientation];

--- a/Server/AutomationActions/Gestures/EventSynthesis/TouchPath.h
+++ b/Server/AutomationActions/Gestures/EventSynthesis/TouchPath.h
@@ -2,6 +2,7 @@
 #import <CoreGraphics/CoreGraphics.h>
 #import <Foundation/Foundation.h>
 #import "XCPointerEventPath.h"
+#import <UIKit/UIKit.h>
 
 /**
  Wrapper class for `XCTouchPath` and `XCPointerEventPath` which
@@ -9,7 +10,7 @@
  testmanagerd.
  */
 @interface TouchPath : NSObject
-@property (nonatomic, readonly) long long orientation;
+@property (nonatomic, readonly) UIInterfaceOrientation orientation;
 
 /**
  Static initializer. Note that the event **does not** perform any actual touches
@@ -21,7 +22,7 @@
  @return A new TouchPath instance.
  */
 + (instancetype)withFirstTouchPoint:(CGPoint)firstTouchPoint
-                        orientation:(long long)orientation;
+                        orientation:(UIInterfaceOrientation)orientation;
 
 /**
  Static initializer. Note that the event **does not** perform any actual touches
@@ -35,7 +36,7 @@
  @return A new TouchPath instance.
  */
 + (instancetype)withFirstTouchPoint:(CGPoint)firstTouchPoint
-                        orientation:(long long)orientation
+                        orientation:(UIInterfaceOrientation)orientation
                              offset:(float)seconds;
 
 /**
@@ -62,4 +63,5 @@
  @return The XCPointerEventPath created as a result of the touch points added
  */
 - (XCPointerEventPath *)eventPath;
+
 @end

--- a/Server/AutomationActions/Gestures/EventSynthesis/TouchPath.m
+++ b/Server/AutomationActions/Gestures/EventSynthesis/TouchPath.m
@@ -6,7 +6,7 @@
 @property (nonatomic) CGPoint lastPoint;
 
 - (instancetype)initWithFirstTouchPoint:(CGPoint)firstTouchPoint
-                            orientation:(long long)orientation
+                            orientation:(UIInterfaceOrientation)orientation
                                  offset:(float)seconds;
 
 + (XCPointerEventPath *)eventPathForFirstTouchPoint:(CGPoint)point
@@ -18,7 +18,7 @@
 
 // private
 - (instancetype)initWithFirstTouchPoint:(CGPoint)firstTouchPoint
-                            orientation:(long long)orientation
+                            orientation:(UIInterfaceOrientation)orientation
                                  offset:(float)seconds {
     self = [super init];
     if (self) {
@@ -34,7 +34,7 @@
 
 // public
 + (instancetype)withFirstTouchPoint:(CGPoint)firstTouchPoint
-                        orientation:(long long)orientation {
+                        orientation:(UIInterfaceOrientation)orientation {
     return [[TouchPath alloc] initWithFirstTouchPoint:firstTouchPoint
                                           orientation:orientation
                                                offset:0.0];
@@ -42,7 +42,7 @@
 
 // public
 + (instancetype)withFirstTouchPoint:(CGPoint)firstTouchPoint
-                        orientation:(long long)orientation
+                        orientation:(UIInterfaceOrientation)orientation
                              offset:(float)seconds {
     return [[TouchPath alloc] initWithFirstTouchPoint:firstTouchPoint
                                           orientation:orientation

--- a/Server/AutomationActions/Gestures/Pinch.m
+++ b/Server/AutomationActions/Gestures/Pinch.m
@@ -19,7 +19,8 @@
     float duration = [self duration];
     float amount = [self pinchAmount];
     NSString *direction = [self pinchDirection];
-    long long orientation = [[Application currentApplication] longLongInterfaceOrientation];
+    UIInterfaceOrientation orientation = [[Application currentApplication]
+                                          interfaceOrientation];
     
     CGPoint p1 = center,
     p2 = center;

--- a/Server/AutomationActions/Gestures/Rotate.m
+++ b/Server/AutomationActions/Gestures/Rotate.m
@@ -109,8 +109,8 @@ float dtor(float degrees) { return degrees * (M_PI / 180); }
 - (CBXTouchEvent *)cbxEventWithCoordinates:(NSArray<Coordinate *> *)coordinates {
     NSArray<NSArray<Coordinate *> *> *circleCoords = [self setup:coordinates];
     
-    long long orientation = [[Application currentApplication]
-                             longLongInterfaceOrientation];
+    UIInterfaceOrientation orientation = [[Application currentApplication]
+                                          interfaceOrientation];
 
     CBXTouchEvent *event = [CBXTouchEvent new];
 

--- a/Server/AutomationActions/Gestures/Touch.m
+++ b/Server/AutomationActions/Gestures/Touch.m
@@ -49,8 +49,8 @@
 
 - (CBXTouchEvent *)cbxEventWithCoordinates:(NSArray <Coordinate *> *)coordinates {
 
-    long long orientation = [[Application currentApplication]
-                             longLongInterfaceOrientation];
+    UIInterfaceOrientation orientation = [[Application currentApplication]
+                                          interfaceOrientation];
 
     CGPoint coordinate = coordinates[0].cgpoint;
 

--- a/Server/AutomationActions/Gestures/TwoFingerTap.m
+++ b/Server/AutomationActions/Gestures/TwoFingerTap.m
@@ -31,8 +31,8 @@
 
 - (CBXTouchEvent *)cbxEventWithCoordinates:(NSArray <Coordinate *> *)coordinates {
 
-    long long orientation = [[Application currentApplication]
-                             longLongInterfaceOrientation];
+    UIInterfaceOrientation orientation = [[Application currentApplication]
+                                          interfaceOrientation];
 
     CGPoint coordinate = coordinates[0].cgpoint;
 

--- a/TestApp/UnitTests/AutomationActions/Gestures/EventSynthesis/CBXTouchEventTests.m
+++ b/TestApp/UnitTests/AutomationActions/Gestures/EventSynthesis/CBXTouchEventTests.m
@@ -5,12 +5,12 @@
 #import "TouchPath.h"
 #import "XCSynthesizedEventRecord.h"
 
-@interface CBXTouchEvent ()
+@interface CBXTouchEvent (TEST)
 
 @property (nonatomic, strong) XCSynthesizedEventRecord *event;
-@property (nonatomic) long long orientation;
+@property (nonatomic) UIInterfaceOrientation orientation;
 
-+ (XCSynthesizedEventRecord *)eventRecordWithOrientation:(long long) orientation;
++ (XCSynthesizedEventRecord *)eventRecordWithOrientation:(UIInterfaceOrientation) orientation;
 
 @end
 
@@ -33,7 +33,7 @@
 }
 
 - (void)testWithTouchPath {
-    long long orientation = self.touchPath.orientation;
+    UIInterfaceOrientation orientation = self.touchPath.orientation;
 
     id classMock = OCMClassMock([CBXTouchEvent class]);
     OCMExpect([classMock
@@ -47,7 +47,7 @@
 
 - (void)testAddTouchPathOrientationInvalid {
     CGPoint point = CGPointMake(54, 47);
-    long long nextOrientation = self.touchPath.orientation;
+    UIInterfaceOrientation nextOrientation = self.touchPath.orientation;
     TouchPath *nextPath = [TouchPath withFirstTouchPoint:point
                                              orientation:nextOrientation + 1
                                                   offset:1.0];


### PR DESCRIPTION
### Motivation

I have made this change twice in the context of researching bugs: Xcode 8.3 support and `the one bug`. 

Replaces `long long` type with `UIInterfaceOrientation` in the context of `XCUIApplication#interfaceOrientation`.

Recall the problems we had with text entry on i386 and armv7 architectures.  These problems were caused by the use of a `long long` type in place of a `NSUInteger` type.   I want to rule out this kind of type mismatch so I don't have to investigate it as a potential problem in the future.

### Test

- [x] cucumber targeting arm64 device
- [x] cucumber targeting x86_64 simulator
- [x] cucumber targeting armv7 device
- [x] cucumber targeting i386 simulator


