### PR TITLE
Server: GET /version returns DeviceAgent build info

### DIFF
--- a/Server/Utilities/CBXInfoPlist.h
+++ b/Server/Utilities/CBXInfoPlist.h
@@ -16,14 +16,29 @@
 - (NSString *)bundleIdentifier;
 
 /**
- Returns the CFBundleVersion - AKA the build version.
+ Returns the CFBundleVersion - the build version.
  */
 - (NSString *)bundleVersion;
 
 /**
- Returns the CFBundleShortVersionString - AKA the marketing version.
+ Returns the CFBundleShortVersionString - the marketing version.
  */
 - (NSString *)bundleShortVersion;
+
+/**
+ * Returns the DTPlatformVersion - the iOS SDK Version
+ */
+- (NSString *)platformVersion;
+
+/**
+ * Returns the DTXcode - the version of Xcode used to build DeviceAgent
+ */
+- (NSString *)xcodeVersion;
+
+/**
+ * Returns the MinimumOSVersion - iOS Deployment Target
+ */
+- (NSString *)minimumOSVersion;
 
 /**
  Returns a dictionary of version information.

--- a/Server/Utilities/CBXInfoPlist.m
+++ b/Server/Utilities/CBXInfoPlist.m
@@ -40,13 +40,28 @@
     return [self stringForKey:@"CFBundleShortVersionString"];
 }
 
+- (NSString *)platformVersion {
+    return [self stringForKey:@"DTPlatformVersion"];
+}
+
+- (NSString *)xcodeVersion {
+    return [self stringForKey:@"DTXcode"];
+}
+
+- (NSString *)minimumOSVersion {
+    return [self stringForKey:@"MinimumOSVersion"];
+}
+
 - (NSDictionary *)versionInfo {
-   return @{
-            @"bundle_version" : [self bundleVersion],
-            @"bundle_short_version" : [self bundleShortVersion],
-            @"bundle_identifier" : [self bundleIdentifier],
-            @"bundle_name" : [self bundleName],
-            };
+    return @{
+             @"bundle_version" : [self bundleVersion],
+             @"bundle_short_version" : [self bundleShortVersion],
+             @"bundle_identifier" : [self bundleIdentifier],
+             @"bundle_name" : [self bundleName],
+             @"platform_version" : [self platformVersion],
+             @"xcode_version" : [self xcodeVersion],
+             @"minimum_os_version" : [self minimumOSVersion]
+             };
 }
 
 @end

--- a/TestApp/UnitTests/Utilities/CBXInfoPlistTest.m
+++ b/TestApp/UnitTests/Utilities/CBXInfoPlistTest.m
@@ -122,12 +122,52 @@ describe(@"CBXInfoPlist", ^{
                 [[[infoMock expect] andReturn:mockedPlist] infoDictionary];
                 expect([infoMock bundleShortVersion]).to.equal(@"foo");
             });
-            
+
             it(@"value does not exist", ^{
                 [[[infoMock expect] andReturn:@{}] infoDictionary];
                 expect([infoMock bundleShortVersion]).to.beEmpty();
             });
         });
+
+        describe(@"DTPlatformVersion", ^{
+            it(@"value exists", ^{
+                mockedPlist = @{@"DTPlatformVersion" : @"foo"};
+                [[[infoMock expect] andReturn:mockedPlist] infoDictionary];
+                expect([infoMock platformVersion]).to.equal(@"foo");
+            });
+
+            it(@"value does not exist", ^{
+                [[[infoMock expect] andReturn:@{}] infoDictionary];
+                expect([infoMock platformVersion]).to.beEmpty();
+            });
+        });
+
+        describe(@"DTXcode", ^{
+            it(@"value exists", ^{
+                mockedPlist = @{@"DTXcode" : @"foo"};
+                [[[infoMock expect] andReturn:mockedPlist] infoDictionary];
+                expect([infoMock xcodeVersion]).to.equal(@"foo");
+            });
+
+            it(@"value does not exist", ^{
+                [[[infoMock expect] andReturn:@{}] infoDictionary];
+                expect([infoMock xcodeVersion]).to.beEmpty();
+            });
+        });
+
+        describe(@"MinimumOSVersion", ^{
+            it(@"value exists", ^{
+                mockedPlist = @{@"MinimumOSVersion" : @"foo"};
+                [[[infoMock expect] andReturn:mockedPlist] infoDictionary];
+                expect([infoMock minimumOSVersion]).to.equal(@"foo");
+            });
+
+            it(@"value does not exist", ^{
+                [[[infoMock expect] andReturn:@{}] infoDictionary];
+                expect([infoMock minimumOSVersion]).to.beEmpty();
+            });
+        });
+
     });
 
     describe(@"versionInfo", ^{
@@ -137,6 +177,9 @@ describe(@"CBXInfoPlist", ^{
             OCMExpect([mockPlist bundleShortVersion]).andReturn(@"1.0.0");
             OCMExpect([mockPlist bundleName]).andReturn(@"CBX");
             OCMExpect([mockPlist bundleIdentifier]).andReturn(@"com.example.CBX");
+            OCMExpect([mockPlist platformVersion]).andReturn(@"10.3");
+            OCMExpect([mockPlist xcodeVersion]).andReturn(@"8.3");
+            OCMExpect([mockPlist minimumOSVersion]).andReturn(@"9.1");
 
             NSDictionary *expected =
             @{
@@ -144,6 +187,9 @@ describe(@"CBXInfoPlist", ^{
               @"bundle_short_version" : @"1.0.0",
               @"bundle_name" : @"CBX",
               @"bundle_identifier" : @"com.example.CBX",
+              @"platform_version" : @"10.3",
+              @"xcode_version" : @"8.3",
+              @"minimum_os_version" : @"9.1"
               };
 
             expect([mockPlist versionInfo]).to.equal(expected);

--- a/cucumber/features/meta.feature
+++ b/cucumber/features/meta.feature
@@ -1,12 +1,14 @@
 @meta
 Feature: Meta Routes
 
+@info
 Scenario: Calling meta routes
 Given the app has launched
 Then I can ask for the server version
 And I can ask for the session identifier
 And I can ask for information about the device under test
 And I can ask for the pid of the server
+And I can ask about the build attributes of the DeviceAgent
 
 @springboard
 @springboard_alerts

--- a/cucumber/features/steps/meta.rb
+++ b/cucumber/features/steps/meta.rb
@@ -15,6 +15,17 @@ Then(/^I can ask for the server version$/) do
   expect(actual["bundle_short_version"]).to be_truthy
 end
 
+And(/^I can ask about the build attributes of the DeviceAgent$/) do
+  actual = server_version
+
+  expect(RunLoop::Version.new(actual["platform_version"])).to(
+    be >= RunLoop::Version.new("10.0"))
+  expect(RunLoop::Version.new(actual["xcode_version"])).to(
+    be >= RunLoop::Version.new("7.3.1"))
+  expect(RunLoop::Version.new(actual["minimum_os_version"])).to(
+    be >= RunLoop::Version.new("8.0"))
+end
+
 Then(/^I can ask for the session identifier$/) do
   identifier = session_identifier
 


### PR DESCRIPTION
###  Motivation

This is required to test or assert that DeviceAgent was built with an Xcode version or can target an iOS version.

Progress on:

* https://github.com/xamarin/test-cloud-execution-pipeline/pull/426

