### PR TITLE
Server: NSXPCConnection.h is provided in Xcode 9

### DIFF
--- a/Server/Testmanagerd/Testmanagerd.m
+++ b/Server/Testmanagerd/Testmanagerd.m
@@ -1,11 +1,13 @@
 
 #import "Testmanagerd.h"
 #import "XCTestDriver.h"
-#import "NSXPCConnection.h"
 #import "XCTRunnerDaemonSession.h"
 #import <objc/runtime.h>
 #import "CBXException.h"
 
+#ifndef __IPHONE_11_0
+#import "NSXPCConnection.h"
+#endif
 
 @interface Testmanagerd()
 @end


### PR DESCRIPTION
### Motivation

In Xcode 9.0 beta 2, importing NSXPCConnection.h causes duplicate symbol errors.

Conditionally importing allows us to compile.  The runtime behavior might be incorrect.
