### PR TITLE
Server: add pt-BR alert definition for APNS

### DIFF
--- a/Server/Utilities/SpringBoardAlerts.m
+++ b/Server/Utilities/SpringBoardAlerts.m
@@ -275,6 +275,7 @@ static SpringBoardAlert *alert(NSString *buttonTitle, BOOL shouldAccept, NSStrin
              alert(@"OK", YES, @"Deseja Ter Acesso às Suas Atividades de Movimento e Preparo Físico"),
              alert(@"OK", YES, @"Deseja Ter Acesso às Contas do Twitter"),
              alert(@"OK", YES, @"Deseja enviar-lhe notificações"),
+             alert(@"Permitir", YES, @"Deseja Enviar Notificações"),
              alert(@"Abrir", YES, @"Abrir com")
              ];
 }


### PR DESCRIPTION
### Motivation

Completes:

* Add pt-BR localization to DeviceAgent [VSTS](https://msmobilecenter.visualstudio.com/Mobile-Center/_workitems/edit/11138)
* DeviceAgent does not dismiss APNS springboard alert automatically in portuguese (pt-BR) when running on physical devices [#624](https://github.com/calabash/run_loop/issues/624)