### PR TITLE
Server: OR predicates not evaling correctly on web views - updated tests; issue is not resolved

### DIFF
--- a/cucumber/features/steps/meta.rb
+++ b/cucumber/features/steps/meta.rb
@@ -1,4 +1,32 @@
 
+module TestApp
+  module Meta
+
+   def xcode_version
+     # "0833"
+     # "0900"
+     version = server_version["xcode_version"]
+     chars = version.chars
+     if chars[0] == "0"
+       major = "#{chars[1]}"
+     else
+       # Xcode 10 or higher
+       major = "#{chars[0]}#{chars[1]}"
+     end
+
+     minor = chars[2]
+     patch = chars[3]
+     RunLoop::Version.new("#{major}.#{minor}.#{patch}")
+   end
+
+   def xcode_gte_9?
+     xcode_version >= RunLoop::Version.new("9.0.0")
+   end
+  end
+end
+
+World(TestApp::Meta)
+
 Then(/^I can ask for the server version$/) do
   expected =
     {

--- a/cucumber/features/steps/pan.rb
+++ b/cucumber/features/steps/pan.rb
@@ -55,6 +55,12 @@ module TestApp
         sleep(1.5)
 
         view = query({marked: view_mark}).first
+
+        # OR"d queries are not working in Xcode 9 with WebKit and Safari
+        if !view && xcode_gte_9?
+          view = query({id: view_mark}).first
+        end
+
         if view
           hit_point = view["hit_point"]
           element_center = element_center(view)

--- a/cucumber/features/steps/webview.rb
+++ b/cucumber/features/steps/webview.rb
@@ -8,7 +8,8 @@ Given(/^I am looking at the (UIWebView|WKWebView|SafariWebController)$/) do |typ
     touch({marked: "safari web controller row"})
     @safari_controller = true
   end
-  wait_for_view({marked: "H1 Header!"})
+
+  wait_for_view({id: "H1 Header!"})
 end
 
 And(/^I scroll down to the first and last name text fields$/) do

--- a/cucumber/features/webview.feature
+++ b/cucumber/features/webview.feature
@@ -16,7 +16,7 @@ And I can type my first name
 Then I clear my first name using the clear text route
 
 @keyboard
-@uiwebview
+@wkwebview
 Scenario: Interacting with WKWebView text field
 Given I am looking at the WKWebView
 And I scroll down to the first and last name text fields


### PR DESCRIPTION
### Motivation

Completes:

* Xcode 9: Cannot find "H1 Header" on web pages [VSTS](https://msmobilecenter.visualstudio.com/Mobile-Center/_workitems/edit/14798)

Related:

* Xcode 9: OR'd NSPredicates are not working on WK and Safari WebViews [VSTS](https://msmobilecenter.visualstudio.com/Mobile-Center/_workitems/edit/14910)