### PR TITLE
Server: revert pull request #237 - remove pre-launch is-installed check; does not work on iOS 11

### DIFF
--- a/Server/Application/Application.h
+++ b/Server/Application/Application.h
@@ -42,15 +42,4 @@
  */
 + (BOOL)hasSession;
 
-/**
- Uses the XCUIApplication#exists class method to check if an app is installed.
-
- Previously we used LSApplicationWorkspace, but starting in Xcode 9 this
- strategy stopped working.
-
- @param bundleIdentifier The application to search for
- @return True if the application with bundle identifier is installed
- */
-+ (BOOL)applicationIsInstalled:(NSString *_Nonnull)bundleIdentifier;
-
 @end

--- a/Server/Application/Application.m
+++ b/Server/Application/Application.m
@@ -20,12 +20,6 @@ static Application *currentApplication;
     });
 }
 
-+ (BOOL)applicationIsInstalled:(NSString *)bundleIdentifier {
-    XCUIApplication *app = [[XCUIApplication alloc] initPrivateWithPath:nil
-                                                               bundleID:bundleIdentifier];
-    return [app exists];
-}
-
 + (BOOL)hasSession {
     return [currentApplication hasSession];
 }

--- a/Server/Routes/SessionRoutes.m
+++ b/Server/Routes/SessionRoutes.m
@@ -19,16 +19,11 @@
                  NSNumber *terminateNumber = json[CBX_TERMINATE_AUT_IF_RUNNING_KEY] ?: @(NO);
                  BOOL terminateIfRunning = [terminateNumber boolValue];
 
-                 NSAssert(bundleID, @"Must specify \"bundleID\"");
                  if (!bundlePath || [bundlePath isEqual:[NSNull null]]) {
                      bundlePath = nil;
-
-                     if (![Application applicationIsInstalled:bundleID]) {
-                         NSString *errorMsg;
-                         errorMsg = [NSString stringWithFormat:@"Application with identifier: %@ is not installed.",
-                                     bundleID];
-                         @throw [CBXException withMessage:errorMsg userInfo:nil];
-                     }
+                     // Starting in Xcode 9, we can no longer check if the
+                     // if the AUT is installed using the LSApplication* private
+                     // methods or an XCUIApplication#exists query.
                  } else {
                      // Passing bundle paths is supported, but not well understood.
                      // See the docs in Application.h


### PR DESCRIPTION
### Motivation

XCUIApplication#exists does not work on Xcode 9

Relates:

* Use XCUIApplication to check if application is installed before launch #237

Completes:

* DeviceAgent is-installed check is failing for Xcode 9. [VSTS](https://msmobilecenter.visualstudio.com/Mobile-Center/_workitems/edit/14788)

