### PR TITLE
Server: decrease default touch time to 0.1 

### DIFF
--- a/Server/CBXConstants.h
+++ b/Server/CBXConstants.h
@@ -100,8 +100,15 @@ static float const CBX_MAX_ROTATION_START = 360;    //degrees
 // determined empirically with UILongPressGestureRecognizer
 static float const CBX_MIN_LONG_PRESS_DURATION = 0.5;
 
-// determined by observing testmanagerd logs for XCUIElement#tap gestures.
-static float const CBX_DEFAULT_DURATION = 0.2;
+// In iOS 10, we observed that the default duration was 0.2 by inspecting
+// testmanagerd logs for XCUIElement#tap gestures.
+//
+// In iOS 11, a touch of 0.2 is too long for some controls, for example,
+// UISegmentedControl.
+//
+// If 0.1 is too short for some control on iOS < 11, we will have to branch
+// on iOS version at runtime.
+static float const CBX_DEFAULT_DURATION = 0.1;
 static BOOL const CBX_DEFAULT_ALLOW_INERTIA_IN_DRAG = YES;
 
 // determined by observing testmanagerd logs for XCUIElement double tap gestures.

--- a/TestApp/UITests/UITest.m
+++ b/TestApp/UITests/UITest.m
@@ -32,6 +32,12 @@
 //                   [@(interfaceOrientation) integerValue]);
 }
 
+
+- (void)testSegmentedControl {
+    [XCUIDevice sharedDevice].orientation = UIDeviceOrientationPortrait;
+    [self.aut.segmentedControls[@"segmented"].buttons[@"Second"] tap];
+}
+
 - (void)testTextEntry {
     [XCUIDevice sharedDevice].orientation = UIDeviceOrientationPortrait;
 


### PR DESCRIPTION
### Motivation

The previous value of 0.2 was too long for interacting with controls such as UISegmentedControl.

Completes:

* iOS 11: selected attribute of UISegmentedControl is not correct [VSTS](https://msmobilecenter.visualstudio.com/Mobile-Center/_workitems/edit/15204)

It is possible that this change will break existing tests.  We might need to branch on iOS version to determine the correct minimum touch duration.

### Tests

- [x] iOS 10.3
- [x] iOS 11.0 beta 5