### PR TITLE
Server: XCUIApplication cannot be first responder

### DIFF
--- a/Server/Utilities/TextInputFirstResponderProvider.h
+++ b/Server/Utilities/TextInputFirstResponderProvider.h
@@ -14,11 +14,4 @@
  */
 - (XCUIElement *)firstResponder;
 
-/**
- * Queries the AUT for the TextField, TextView, SecureTextField, or Other element type
- * for the XCUIElement that has keyboard focus.
- * @return the XCUIElement with keyboard focus or the XCUIApplication reference to the AUT
- */
-- (XCUIElement *)firstResponderOrApplication;
-
 @end

--- a/Server/Utilities/TextInputFirstResponderProvider.m
+++ b/Server/Utilities/TextInputFirstResponderProvider.m
@@ -55,12 +55,4 @@
     return firstResponder;
 }
 
-- (XCUIElement *)firstResponderOrApplication {
-    XCUIElement *firstResponder = [self firstResponder];
-    if (!firstResponder) {
-        firstResponder = [Application currentApplication];
-    }
-    return firstResponder;
-}
-
 @end


### PR DESCRIPTION
### Motivation

Completes:

* XCUIApplication#typeText will not work on iOS 10.3 or higher [VSTS](https://msmobilecenter.visualstudio.com/Mobile-Center/_workitems/edit/14942)

Remove the ability to fall back to XCUIApplication if no view is a first responder.