### PR TITLE
Xcode 9: redirect simulator logs to ~/Library/CoreSimulator/<UDID>/system.log

### DIFF
--- a/Server/CBXCUITestServer.m
+++ b/Server/CBXCUITestServer.m
@@ -65,7 +65,31 @@ static NSString *serverName = @"CalabashXCUITestServer";
     return shared;
 }
 
++ (void)redirectSimulatorLogsToUserLibraryCoreSimulatorLogs {
+#ifdef __IPHONE_11_0
+#if TARGET_IPHONE_SIMULATOR
+    NSArray *paths = NSSearchPathForDirectoriesInDomains(NSLibraryDirectory,
+                                                         NSUserDomainMask, YES);
+    if (!paths[0]) { return; }
+    NSString *containerLibrary = paths[0];
+    NSArray *tokens = [containerLibrary componentsSeparatedByString:@"data"];
+
+    if (!tokens[0]) { return; }
+    NSString *dataDir = [tokens[0] stringByAppendingPathComponent:@"data"];
+    NSString *libraryDir = [dataDir stringByAppendingPathComponent:@"Library"];
+    NSString *logsDir = [libraryDir stringByAppendingPathComponent:@"Logs"];
+    NSString *sysLog = [logsDir stringByAppendingPathComponent:@"system.log"];
+
+    if (![[NSFileManager defaultManager] fileExistsAtPath:sysLog]) { return; }
+
+    freopen([sysLog fileSystemRepresentation], "a+", stderr);
+    freopen([sysLog fileSystemRepresentation], "a+", stdout);
+#endif
+#endif
+}
+
 + (void)start {
+    [CBXCUITestServer redirectSimulatorLogsToUserLibraryCoreSimulatorLogs];
     [CBXLogging startLumberjackLogging];
 
     DDLogDebug(@"%@ built at %s %s", serverName, __DATE__, __TIME__);


### PR DESCRIPTION
### Motivation

Completes:

* Lumberjack and NSLog messages are not appear in CoreSimulator logs [VSTS](https://msmobilecenter.visualstudio.com/Mobile-Center/_workitems/edit/20055)

Patch submitted by OSS user @JoeSSS.
