### PR TITLE
Server: handle 3 button SpringBoard location alert

### DIFF
--- a/Server/Application/SpringBoard.m
+++ b/Server/Application/SpringBoard.m
@@ -219,7 +219,33 @@ typedef enum : NSUInteger {
         }
 
         if (springBoardAlert.shouldAccept) {
-            button = buttons.lastObject;
+            switch ([buttons count]) {
+
+                case 1: {
+                    // Single button alert
+                    button = buttons[0];
+                    break;
+                }
+                case 2: {
+                    // Two button alert
+                    button = buttons[1];
+                    break;
+                }
+                case 3: {
+                    // Three button alert
+                    // Allow Location Always notification started popping this
+                    // alert in iOS 11.
+                    button = buttons[1];
+                    break;
+                }
+
+                default: {
+                    button = buttons.lastObject;
+                    break;
+                }
+
+            }
+
         } else {
             button = buttons.firstObject;
         }


### PR DESCRIPTION
### Motivation

* DeviceAgent does not dismiss iOS 11 three-button Location alerts [VSTS](https://msmobilecenter.visualstudio.com/Mobile-Center/_workitems/edit/21939)

### Tests

* https://testcloud.xamarin.com/test/permissions_8d3cfdac-cf5d-4577-8706-88ca81b93c46/
* https://testcloud.xamarin.com/test/permissions_61532d6f-3de6-448b-9d15-3ff5d5d00f4d/

Failures are unrelated to this feature.