### PR TITLE
Server: update CBXDevice with iPhone 8 and 10 models

### DIFF
--- a/Server/Utilities/CBXDevice.h
+++ b/Server/Utilities/CBXDevice.h
@@ -88,6 +88,11 @@ extern NSString *const CBXDeviceSimKeyVersionInfo;
 - (BOOL) isIPadPro10point5inch;
 
 /**
+ @return True if the device has an iPhone X form factor.
+ */
+- (BOOL) isIPhone10Like;
+
+/**
  @return True if the device is arm64
  */
 - (BOOL)isArm64;

--- a/Server/Utilities/CBXDevice.m
+++ b/Server/Utilities/CBXDevice.m
@@ -244,6 +244,14 @@ NSString *const CBXDeviceSimKeyVersionInfo = @"SIMULATOR_VERSION_INFO";
       @"iPhone9,2" : @"iphone 6+",
       @"iPhone9,4" : @"iphone 6+",
 
+      // iPhone 8/8+/X - derived from Simulator
+      @"iPhone10,1" : @"iphone 6",
+      @"iPhone10,4" : @"iphone 6",
+      @"iPhone10,5" : @"iphone 6+",
+      @"iPhone10,2" : @"iphone 6+",
+      @"iPhone10,3" : @"iphone 10",
+      @"iPhone10,6" : @"iphone 10",
+
       // iPad Pro 13in
       @"iPad6,7" : @"ipad pro",
       @"iPad6,8" : @"ipad pro",
@@ -443,6 +451,10 @@ NSString *const CBXDeviceSimKeyVersionInfo = @"SIMULATOR_VERSION_INFO";
 
 - (BOOL) isIPadPro10point5inch {
     return [[self modelIdentifier] containsString:@"iPad7"];
+}
+
+- (BOOL) isIPhone10Like {
+    return [[self formFactor] isEqualToString:@"iphone 10"];
 }
 
 - (BOOL)isArm64 {

--- a/TestApp/UnitTests/Utilities/CBXDeviceTest.m
+++ b/TestApp/UnitTests/Utilities/CBXDeviceTest.m
@@ -358,6 +358,24 @@ static NSString *const LPiPhone5sSimVersionInfo = @"CoreSimulator 110.4 - Device
     OCMVerifyAll(mock);
 }
 
+- (void)testIsIPhone10LikeNO {
+    id mock = OCMPartialMock(self.device);
+    OCMExpect([mock formFactor]).andReturn(@"garbage");
+
+    expect([mock isIPhone10Like]).to.equal(NO);
+
+    OCMVerifyAll(mock);
+}
+
+- (void)testIsIPhone10LikeYES {
+    id mock = OCMPartialMock(self.device);
+    OCMExpect([mock formFactor]).andReturn(@"iphone 10");
+
+    expect([mock isIPhone10Like]).to.equal(YES);
+
+    OCMVerifyAll(mock);
+}
+
 - (void)testIsLetterBoxNoBecauseIpad {
     id mock = OCMPartialMock(self.device);
     OCMExpect([mock isIPad]).andReturn(YES);


### PR DESCRIPTION
### Motivation

iPhone 8, 8+, and 10 device models have been released.