### PR TITLE
SB: add camera alert for iOS 11 de

### DIFF
--- a/Server/Utilities/SpringBoardAlerts.m
+++ b/Server/Utilities/SpringBoardAlerts.m
@@ -207,6 +207,7 @@ static SpringBoardAlert *alert(NSString *buttonTitle, BOOL shouldAccept, NSStrin
              alert(@"Erlauben", YES, @"möchte auf Twitter-Accounts zugreifen"),
              alert(@"Ja", YES, @"auf das Mikrofon zugreifen"),
              alert(@"Ja", YES, @"möchte auf Ihre Bewegungs- und Fitnessdaten zugreifen"),
+             alert(@"OK", YES, @"möchte auf deine Kamera zugreifen"),
              alert(@"Ja", YES, @"auf Ihre Kamera zugreifen"),
              alert(@"OK", YES, @"Ihnen Mitteilungen senden"),
              alert(@"OK", YES, @"Keine SIM-Karte eingelegt"),


### PR DESCRIPTION
### Motivation

Resolves:

* German springboard alert for Camera permission is not dismissed [#1344](https://github.com/calabash/calabash-ios/issues/1344)