### PR TITLE
Add iOS 11 'would like to add to your photos'  SpringBoard alert

### DIFF
--- a/Server/Utilities/SpringBoardAlerts.m
+++ b/Server/Utilities/SpringBoardAlerts.m
@@ -103,6 +103,7 @@ static SpringBoardAlert *alert(NSString *buttonTitle, BOOL shouldAccept, NSStrin
              alert(@"Allow", YES, @"access your location"),
              alert(@"OK", YES, @"Health Access"),
              alert(@"OK", YES, @"Would Like to Access Your Photos"),
+             alert(@"OK", YES, @"Would like to Add to your Photos"),
              alert(@"OK", YES, @"Would Like to Access Your Contacts"),
              alert(@"OK", YES, @"Access the Microphone"),
              alert(@"OK", YES, @"Would Like to Access Your Calendar"),


### PR DESCRIPTION
### Motivation

Completes:

* DeviceAgent does not dismiss iOS 11 "Would like to add to your photos" SpringBoard alerts [VSTS](https://msmobilecenter.visualstudio.com/Mobile-Center/_workitems/edit/27757)