### PR TITLE
Server: XCUIElement with type Any may or may not respond to WebDriver methods

### DIFF
--- a/Server/Utilities/JSONUtils.m
+++ b/Server/Utilities/JSONUtils.m
@@ -21,25 +21,35 @@ static NSDictionary *typeStringToElementType;
         }
     }
 
-    json[CBX_TYPE_KEY] = snapshotOrElement.wdType;
-    json[CBX_LABEL_KEY] = snapshotOrElement.wdLabel;
-    json[CBX_TITLE_KEY] = snapshotOrElement.wdTitle;
-    json[CBX_VALUE_KEY] = snapshotOrElement.wdValue;
-    json[CBX_PLACEHOLDER_KEY] = snapshotOrElement.wdPlaceholderValue;
-    json[CBX_RECT_KEY] = [self rectToJSON:snapshotOrElement.wdFrame];
-    json[CBX_IDENTIFIER_KEY] = snapshotOrElement.wdName;
-    json[CBX_ENABLED_KEY] = @(snapshotOrElement.wdEnabled);
-    json[CBX_SELECTED_KEY] = @(snapshotOrElement.wdSelected);
-    json[CBX_HAS_FOCUS_KEY] = @(snapshotOrElement.wdHasFocus);
-    json[CBX_HAS_KEYBOARD_FOCUS_KEY] = @(snapshotOrElement.wdHasKeyboardFocus);
+    // Occasionally XCUIElement with type 'Any' are not responding to the
+    // WebDriverAgent methods.
+    @try {
+        json[CBX_TYPE_KEY] = snapshotOrElement.wdType;
+        json[CBX_LABEL_KEY] = snapshotOrElement.wdLabel;
+        json[CBX_TITLE_KEY] = snapshotOrElement.wdTitle;
+        json[CBX_VALUE_KEY] = snapshotOrElement.wdValue;
+        json[CBX_PLACEHOLDER_KEY] = snapshotOrElement.wdPlaceholderValue;
+        json[CBX_RECT_KEY] = [self rectToJSON:snapshotOrElement.wdFrame];
+        json[CBX_IDENTIFIER_KEY] = snapshotOrElement.wdName;
+        json[CBX_ENABLED_KEY] = @(snapshotOrElement.wdEnabled);
+        json[CBX_SELECTED_KEY] = @(snapshotOrElement.wdSelected);
+        json[CBX_HAS_FOCUS_KEY] = @(snapshotOrElement.wdHasFocus);
+        json[CBX_HAS_KEYBOARD_FOCUS_KEY] = @(snapshotOrElement.wdHasKeyboardFocus);
 
-    BOOL visible;
-    CGPoint hitPoint;
-    [snapshotOrElement getHitPoint:&hitPoint visibility:&visible];
+        BOOL visible;
+        CGPoint hitPoint;
+        [snapshotOrElement getHitPoint:&hitPoint visibility:&visible];
 
-    json[CBX_HITABLE_KEY] = @(visible);
-    json[CBX_HIT_POINT_KEY] = @{@"x" : [JSONUtils normalizeFloat:hitPoint.x],
-                                @"y" : [JSONUtils normalizeFloat:hitPoint.y]};
+        json[CBX_HITABLE_KEY] = @(visible);
+        json[CBX_HIT_POINT_KEY] = @{@"x" : [JSONUtils normalizeFloat:hitPoint.x],
+                                    @"y" : [JSONUtils normalizeFloat:hitPoint.y]};
+    } @catch (NSException *exception) {
+        DDLogError(@"Caught an exception converting '%@' with class '%@' to JSON:\n%@",
+                   snapshotOrElement, [snapshotOrElement class], [exception reason]);
+        DDLogError(@"returning an empty dictionary after converting this much of the"
+                   "instance to JSON:\n%@", json);
+        json = [NSMutableDictionary dictionary];
+    }
 
     return json;
 }


### PR DESCRIPTION
### Motivation

Completes:

* DeviceAgent: cucumber failing because [XCUIElement wdType]: unrecognized selector sent to instance [VSTS](https://msmobilecenter.visualstudio.com/Mobile-Center/_workitems/edit/27284)

I tried the "responds to selector" dance with a fall back to `XCUIElement#elementType`.  

1. I found many many cases where XCUIElement _did not_ respond to `wdType` which is confusing because this error is incredibly rare and hard to reproduce.  I can only understand this as `respondsToSelector` is returning `NO`, but sending the selector to instance succeeds. 
2.  After falling back to `elementType`, sometimes the next selector (`wdLabel`) failed.
3. The XCUIElement instance that is causing the exception in the title has type `XCUIElementTypeAny`. 

My conclusion is that elements with type `XCUIElementTypeAny` may or may not respond to the WebDriver methods.   The quickest way to handle this problem is to catch the "does not respond to selector"  exceptions and log them.  A more principled solution would be to do the "responds to selector"  dance for every WebDriver method.  Another alternative would be to stop using the WebDriver methods.  As a reminder the WebDriver methods allow the JSON conversion method to  convert either an `XCElementSnapshot` or `XCUIElement`. 