### PR TITLE
Server: drag-n-drop can start with a touch-and-hold

### DIFF
--- a/Server/AutomationActions/Gestures/Drag.h
+++ b/Server/AutomationActions/Gestures/Drag.h
@@ -4,7 +4,7 @@
 /**
  Drag between any number of coordinates with up to 5 fingers.
 
-Currently, the positions of the fingers beyond the first are determined by 
+ The positions of the fingers beyond the first are determined by
  +[GeometryUtils fingerOffsetForFingerIndex:] 
  
  You can repeat the gesture any number of times by using the `repetitions` key.
@@ -25,6 +25,7 @@ Currently, the positions of the fingers beyond the first are determined by
  -  CBX_DURATION_KEY
  -  CBX_NUM_FINGERS_KEY
  -  CBX_HOLD_DURATION_KEY
+ -  CBX_FIRST_TOUCH_HOLD_DURATION_DRAG_KEY
  
  */
 @interface Drag : Gesture<Gesture>

--- a/Server/AutomationActions/Gestures/Drag.m
+++ b/Server/AutomationActions/Gestures/Drag.m
@@ -8,8 +8,14 @@
 
 + (NSArray <NSString *> *)optionalKeys {
     return @[CBX_ALLOW_INERTIA_DRAG_KEY,
+             // How long the first touch needs to activate or grab the element.
+             CBX_FIRST_TOUCH_HOLD_DURATION_DRAG_KEY,
+             // The duration of the gesture - how long is this drag?
+             // This does not include any time spent holding the element before
+             // panning. See above.
              CBX_DURATION_KEY,
-             CBX_NUM_FINGERS_KEY];
+             CBX_NUM_FINGERS_KEY
+             ];
 }
 
 - (void)validate {
@@ -38,7 +44,7 @@
 
     UIInterfaceOrientation orientation = [[Application currentApplication]
                                           interfaceOrientation];
-    
+
     for (int fingerIndex = 0; fingerIndex < [self numFingers]; fingerIndex++ ) {
         CGPoint fingerOffset = [GeometryUtils fingerOffsetForFingerIndex:fingerIndex];
         CGPoint point = coordinates[0].cgpoint;
@@ -53,7 +59,15 @@
             TouchPath *path = [TouchPath withFirstTouchPoint:point orientation:orientation];
 
             for (Coordinate *coordinate in coordinates) {
-                if (coordinate == coordinates.firstObject) { continue; }
+                if (coordinate == coordinates.firstObject) {
+                    if ([self dragFirstTouchHoldDuration] > 0.0) {
+                        // Allow the element to be grabbed.
+                        offset = offset + [self dragFirstTouchHoldDuration];
+                    } else {
+                        continue;
+                    }
+                }
+
                 offset += duration;
 
                 // Add an additional point to halt inertia.

--- a/Server/AutomationActions/Gestures/Gesture+Options.h
+++ b/Server/AutomationActions/Gestures/Gesture+Options.h
@@ -32,6 +32,12 @@ Extension to Gesture with convenience methods for attempting to get a value or, 
 - (float)duration;
 
 /**
+ How long the first touch should hold the element before the pan starts.
+ @returns the value passed in the configuration or the default value (0)
+ */
+- (float)dragFirstTouchHoldDuration;
+
+/**
  Defines whether drag gestures are performed in such a way as to avoid inertia being
  performed within scrollable elements.  When NO, the last part of a drag gestures
  is performed 2 pixels longer than requested and is follwed by a 2 pixel 100 ms drag

--- a/Server/AutomationActions/Gestures/Gesture+Options.m
+++ b/Server/AutomationActions/Gestures/Gesture+Options.m
@@ -15,6 +15,10 @@
     return [self getFloat:CBX_DURATION_KEY default:CBX_DEFAULT_DURATION];
 }
 
+- (float)dragFirstTouchHoldDuration {
+    return [self getFloat:CBX_FIRST_TOUCH_HOLD_DURATION_DRAG_KEY default:0.0];
+}
+
 - (BOOL)allowDragToHaveInertia {
     return [self boolForKey:CBX_ALLOW_INERTIA_DRAG_KEY
                     default:CBX_DEFAULT_ALLOW_INERTIA_IN_DRAG];

--- a/Server/CBXConstants.h
+++ b/Server/CBXConstants.h
@@ -32,6 +32,7 @@ static NSString *const CBX_ROTATION_DIRECTION_KEY = @"rotation_direction";
 static NSString *const CBX_RADIUS_KEY = @"radius";
 static NSString *const CBX_DURATION_KEY = @"duration";
 static NSString *const CBX_ALLOW_INERTIA_DRAG_KEY = @"allow_inertia";
+static NSString *const CBX_FIRST_TOUCH_HOLD_DURATION_DRAG_KEY = @"first_touch_hold_duration";
 static NSString *const CBX_CLOCKWISE_KEY = @"clockwise";
 static NSString *const CBX_COUNTERCLOCKWISE_KEY = @"counterclockwise";
 static NSString *const CBX_COORDINATE_KEY = @"coordinate";

--- a/TestApp/UnitTests/AutomationActions/Gestures/Factory/GestureFactoryTests.m
+++ b/TestApp/UnitTests/AutomationActions/Gestures/Factory/GestureFactoryTests.m
@@ -176,7 +176,8 @@
                 @"options" : @{
                         @"duration" : @0.1,
                         @"num_fingers" : @1,
-                        @"allow_inertia" : @YES
+                        @"allow_inertia" : @YES,
+                        @"first_touch_hold_duration" : @0.0
                         }
                 };
     [self expectGestureWithJSON:json gestureClass:[Drag class]];

--- a/cucumber/features/steps/pan.rb
+++ b/cucumber/features/steps/pan.rb
@@ -287,7 +287,13 @@ Then(/^I move the Android row above the Apple row$/) do
 
   from_point = {x: android_center[:x], y: android_center[:y]}
   to_point = {x: apple_center[:x], y: apple_center[:y]}
-  pan_between_coordinates(from_point, to_point)
+
+  pan_between_coordinates(from_point, to_point, {:first_touch_hold_duration => 1.0})
   sleep(0.4)
+
   touch({marked: "Done"})
+  wait_for_no_view({marked: "Done"})
+
+  cells = query({type: "Cell"})
+  expect(cells[1]["id"]).to be == "android row"
 end

--- a/cucumber/features/support/automator.rb
+++ b/cucumber/features/support/automator.rb
@@ -132,7 +132,8 @@ module DeviceAgent
       default_options = {
         :duration => 1.0,
         :num_fingers => 1,
-        :allow_inertia => true
+        :allow_inertia => true,
+        :first_touch_hold_duration => 0.0
       }
       merged_options = default_options.merge(options)
       Automator.client.pan_between_coordinates(from_point, to_point, merged_options)


### PR DESCRIPTION
**FORCE PUSHED: Fri Jan 5 16:29 CET**

### Motivation

Starting in iOS 11, drag-and-drop for tasks like reordering table view cells requires a touch-and-hold to start the gesture.  This touch activates or grabs the element.

Updated the drag gesture to accept a `first_touch_hold_duration` key/value pair.

Progress on:

* UITest: Desk case 433047 - DragCoordinates issue [VSTS](https://msmobilecenter.visualstudio.com/Mobile-Center/_workitems/edit/30950)

### Test

- [x] https://testcloud.xamarin.com/test/3f60ae70-f072-4189-bad7-3311f0adc1d6/
  
  