### PR TITLE
Xcode: target + script for running XCUITests against arbitrary .app

### DIFF
--- a/DeviceAgent.xcodeproj/project.pbxproj
+++ b/DeviceAgent.xcodeproj/project.pbxproj
@@ -556,6 +556,7 @@
 		F5CE18E41E8BBA61001116A5 /* CBLSApplicationProxy.m in Sources */ = {isa = PBXBuildFile; fileRef = F5CE18E11E8BBA61001116A5 /* CBLSApplicationProxy.m */; };
 		F5D086A41F38C96B008B894C /* RevealServer.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F5D086A31F38C96B008B894C /* RevealServer.framework */; };
 		F5D42A191D40E3150041105C /* AVFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F5D42A181D40E3150041105C /* AVFoundation.framework */; };
+		F5DD368E20036D7200308564 /* StandAloneUITests.m in Sources */ = {isa = PBXBuildFile; fileRef = F5DD368D20036D7200308564 /* StandAloneUITests.m */; };
 		F5DED03F1D7634AB00563648 /* SpringBoardAlert.h in Headers */ = {isa = PBXBuildFile; fileRef = F5DED03D1D7634AB00563648 /* SpringBoardAlert.h */; };
 		F5DED0401D7634AB00563648 /* SpringBoardAlert.m in Sources */ = {isa = PBXBuildFile; fileRef = F5DED03E1D7634AB00563648 /* SpringBoardAlert.m */; };
 		F5DED0411D7634AB00563648 /* SpringBoardAlert.m in Sources */ = {isa = PBXBuildFile; fileRef = F5DED03E1D7634AB00563648 /* SpringBoardAlert.m */; };
@@ -621,6 +622,13 @@
 			proxyType = 1;
 			remoteGlobalIDString = 898743BB1C5847B30084FD93;
 			remoteInfo = CBXAppStub;
+		};
+		F5DD369020036D7200308564 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 898743B41C5847B30084FD93 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 898743BB1C5847B30084FD93;
+			remoteInfo = AppStub;
 		};
 /* End PBXContainerItemProxy section */
 
@@ -1149,6 +1157,9 @@
 		F5CE18E11E8BBA61001116A5 /* CBLSApplicationProxy.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CBLSApplicationProxy.m; sourceTree = "<group>"; };
 		F5D086A31F38C96B008B894C /* RevealServer.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = RevealServer.framework; path = Vendor/RevealServer.framework; sourceTree = "<group>"; };
 		F5D42A181D40E3150041105C /* AVFoundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AVFoundation.framework; path = System/Library/Frameworks/AVFoundation.framework; sourceTree = SDKROOT; };
+		F5DD368B20036D7200308564 /* StandAloneUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = StandAloneUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		F5DD368D20036D7200308564 /* StandAloneUITests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = StandAloneUITests.m; sourceTree = "<group>"; };
+		F5DD368F20036D7200308564 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		F5DED03D1D7634AB00563648 /* SpringBoardAlert.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SpringBoardAlert.h; sourceTree = "<group>"; };
 		F5DED03E1D7634AB00563648 /* SpringBoardAlert.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SpringBoardAlert.m; sourceTree = "<group>"; };
 		F5DED0421D76368000563648 /* SpringBoardAlertTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SpringBoardAlertTest.m; sourceTree = "<group>"; };
@@ -1238,6 +1249,13 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		F5DD368820036D7200308564 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
@@ -1252,6 +1270,7 @@
 				F55F7FEA1C6DD07500A945C8 /* Vendor */,
 				F5169D0E1CFE06B700252F52 /* Licenses */,
 				F50BB27C1D73392100264915 /* Permissions */,
+				F5DD368C20036D7200308564 /* StandAloneUITests */,
 				F542EA1A1CC53DD000D87200 /* Frameworks */,
 				898743BD1C5847B30084FD93 /* Products */,
 			);
@@ -1270,6 +1289,7 @@
 				F58D28181D4F964D000FF6C0 /* UITest.xctest */,
 				F50BB27B1D73392100264915 /* Permissions.app */,
 				F50BB2931D73392200264915 /* Dismiss.xctest */,
+				F5DD368B20036D7200308564 /* StandAloneUITests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -2274,6 +2294,15 @@
 			path = Pan;
 			sourceTree = "<group>";
 		};
+		F5DD368C20036D7200308564 /* StandAloneUITests */ = {
+			isa = PBXGroup;
+			children = (
+				F5DD368D20036D7200308564 /* StandAloneUITests.m */,
+				F5DD368F20036D7200308564 /* Info.plist */,
+			);
+			path = StandAloneUITests;
+			sourceTree = "<group>";
+		};
 		F5E1D8871DEC8E8400B72A8E /* Misc */ = {
 			isa = PBXGroup;
 			children = (
@@ -2655,6 +2684,24 @@
 			productReference = F5B0A0CF1CAD3CBC00E056CE /* UnitTest.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
+		F5DD368A20036D7200308564 /* StandAloneUITests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = F5DD369420036D7200308564 /* Build configuration list for PBXNativeTarget "StandAloneUITests" */;
+			buildPhases = (
+				F5DD368720036D7200308564 /* Sources */,
+				F5DD368820036D7200308564 /* Frameworks */,
+				F5DD368920036D7200308564 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				F5DD369120036D7200308564 /* PBXTargetDependency */,
+			);
+			name = StandAloneUITests;
+			productName = StandAloneUITests;
+			productReference = F5DD368B20036D7200308564 /* StandAloneUITests.xctest */;
+			productType = "com.apple.product-type.bundle.ui-testing";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -2717,6 +2764,12 @@
 						CreatedOnToolsVersion = 7.3;
 						TestTargetID = F5954E041CBD2E1200117745;
 					};
+					F5DD368A20036D7200308564 = {
+						CreatedOnToolsVersion = 9.2;
+						DevelopmentTeam = FYD86LA7RE;
+						ProvisioningStyle = Manual;
+						TestTargetID = 898743BB1C5847B30084FD93;
+					};
 				};
 			};
 			buildConfigurationList = 898743B71C5847B30084FD93 /* Build configuration list for PBXProject "DeviceAgent" */;
@@ -2742,6 +2795,7 @@
 				F5169CDF1CFD982800252F52 /* TestAppBuildNumber */,
 				F50BB27A1D73392100264915 /* Permissions */,
 				F50BB2921D73392200264915 /* Dismiss */,
+				F5DD368A20036D7200308564 /* StandAloneUITests */,
 			);
 		};
 /* End PBXProject section */
@@ -2824,6 +2878,13 @@
 				F5169D1C1CFE06CC00252F52 /* CocoaHTTPServer.LICENSE in Resources */,
 				F5169D1B1CFE06C800252F52 /* CocoaAsyncSocket.LICENSE in Resources */,
 				F5169D201CFE06D900252F52 /* RoutingHTTPServer.LICENSE in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		F5DD368920036D7200308564 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -3207,6 +3268,14 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		F5DD368720036D7200308564 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				F5DD368E20036D7200308564 /* StandAloneUITests.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
@@ -3244,6 +3313,11 @@
 			isa = PBXTargetDependency;
 			target = 898743BB1C5847B30084FD93 /* AppStub */;
 			targetProxy = F5B0A0D41CAD3CBC00E056CE /* PBXContainerItemProxy */;
+		};
+		F5DD369120036D7200308564 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 898743BB1C5847B30084FD93 /* AppStub */;
+			targetProxy = F5DD369020036D7200308564 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -3798,6 +3872,58 @@
 			};
 			name = Release;
 		};
+		F5DD369220036D7200308564 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				CODE_SIGN_STYLE = Manual;
+				DEVELOPMENT_TEAM = FYD86LA7RE;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				INFOPLIST_FILE = StandAloneUITests/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = sh.calaba.StandAloneUITests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE = "35102a64-7ce2-4d50-86cb-3270f637174c";
+				PROVISIONING_PROFILE_SPECIFIER = CalabashWildcard;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_TARGET_NAME = AppStub;
+			};
+			name = Debug;
+		};
+		F5DD369320036D7200308564 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				CODE_SIGN_STYLE = Manual;
+				DEVELOPMENT_TEAM = FYD86LA7RE;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				INFOPLIST_FILE = StandAloneUITests/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = sh.calaba.StandAloneUITests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE = "35102a64-7ce2-4d50-86cb-3270f637174c";
+				PROVISIONING_PROFILE_SPECIFIER = CalabashWildcard;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_TARGET_NAME = AppStub;
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -3887,6 +4013,15 @@
 			buildConfigurations = (
 				F5B0A0D61CAD3CBC00E056CE /* Debug */,
 				F5B0A0D71CAD3CBC00E056CE /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+		F5DD369420036D7200308564 /* Build configuration list for PBXNativeTarget "StandAloneUITests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				F5DD369220036D7200308564 /* Debug */,
+				F5DD369320036D7200308564 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Debug;

--- a/DeviceAgent.xcworkspace/xcshareddata/xcschemes/AppStub.xcscheme
+++ b/DeviceAgent.xcworkspace/xcshareddata/xcschemes/AppStub.xcscheme
@@ -39,6 +39,16 @@
                ReferencedContainer = "container:DeviceAgent.xcodeproj">
             </BuildableReference>
          </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "F5DD368A20036D7200308564"
+               BuildableName = "StandAloneUITests.xctest"
+               BlueprintName = "StandAloneUITests"
+               ReferencedContainer = "container:DeviceAgent.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
       <MacroExpansion>
          <BuildableReference

--- a/DeviceAgent.xcworkspace/xcshareddata/xcschemes/StandAloneUITests.xcscheme
+++ b/DeviceAgent.xcworkspace/xcshareddata/xcschemes/StandAloneUITests.xcscheme
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0920"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "F5DD368A20036D7200308564"
+               BuildableName = "StandAloneUITests.xctest"
+               BlueprintName = "StandAloneUITests"
+               ReferencedContainer = "container:DeviceAgent.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/STANDALONE_XCUITEST.md
+++ b/STANDALONE_XCUITEST.md
@@ -1,0 +1,35 @@
+## Stand Alone XCUITest
+
+```shell
+$ bin/standalone-xcuitest/test-app.sh
+
+Run arbitrary XCUITests against any .app
+
+Usage:
+
+bin/standalone-xcuitest/test-app.sh path/to/AUT.app [simulator or device UDID]
+
+* .ipa archives must be expanded.
+* If no UDID is provided, a default will be used.
+* Tests targeting a physical device require the .app
+  is signed for the device.  The app will be installed
+  on the device as part of the xcodebuild command.
+```
+
+This script can be used to run arbitrary XCUITests against any .app.
+
+1. Obtain a .app from the client.  If you are given a .ipa, expand it
+   to reveal the Payload/Example.app.
+2. If you are targetting a physical device, resign the Example.app for
+   the target device.  You do not need to install the Example.app on the
+   device.
+3. Add tests to StandAloneUITests/StandAloneUITests.m.
+4. Run the script as indicated above (see Usage).
+
+Don't commit changes StandAloneUITests.m.
+
+### Troubleshooting
+
+This technique uses an .xctestrun file.
+
+See `man xcodebuild.xctestrun` for more options.

--- a/StandAloneUITests/Info.plist
+++ b/StandAloneUITests/Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>BNDL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+</dict>
+</plist>

--- a/StandAloneUITests/StandAloneUITests.m
+++ b/StandAloneUITests/StandAloneUITests.m
@@ -1,0 +1,23 @@
+
+#import <XCTest/XCTest.h>
+
+@interface StandAloneUITests : XCTestCase
+
+@end
+
+@implementation StandAloneUITests
+
+- (void)setUp {
+    [super setUp];
+    self.continueAfterFailure = NO;
+}
+
+- (void)tearDown {
+    [super tearDown];
+}
+
+- (void)testExample {
+    [[[XCUIApplication alloc] init] launch];
+}
+
+@end

--- a/StandAloneUITests/template.xctestrun
+++ b/StandAloneUITests/template.xctestrun
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>TestTargetName</key>
+	<dict>
+		<key>IsUITestBundle</key>
+		<true/>
+		<key>TestBundlePath</key>
+    <string>__TESTHOST__/PlugIns/StandAloneUITests.xctest</string>
+		<key>TestHostPath</key>
+    <string>__TESTROOT__/__RUNNER__</string>
+		<key>TestingEnvironmentVariables</key>
+		<dict>
+			<key>DYLD_FRAMEWORK_PATH</key>
+			<string></string>
+			<key>DYLD_LIBRARY_PATH</key>
+			<string></string>
+			<key>XCODE_DBG_XPC_EXCLUSIONS</key>
+			<string>com.apple.dt.xctestSymbolicator</string>
+		</dict>
+		<key>UITargetAppPath</key>
+    <string>__TESTROOT__/__AUT_APP__</string>
+		<key>UseUITargetAppProvidedByTests</key>
+		<false/>
+	</dict>
+</dict>
+</plist>

--- a/bin/instruments.sh
+++ b/bin/instruments.sh
@@ -1,0 +1,35 @@
+
+source bin/log.sh
+source bin/xcode.sh
+
+function default_sim_udid {
+  if [ $(xcode_gte_9) = "true" ]; then
+    local version=$(xcode_version)
+    local minor=$(echo $version | cut -d. -f2)
+    local name="iPhone 7 (11.${minor})"
+  else
+    local name="iPhone 7 (10.3.1)"
+  fi
+
+  local udid=$(
+  xcrun instruments -s devices | \
+    grep "${name} \[.*\]" | \
+    perl -lne 'print $& if /[A-F0-9]{8}-([A-F0-9]{4}-){3}[A-F0-9]{12}/'
+  )
+  echo -n $udid
+}
+
+function default_device_udid {
+  local devices=$(xcrun instruments -s devices | grep -E "[a-f0-9]{40}")
+  if [ "${devices}" = "" ]; then
+    echo ""
+  fi
+
+  # Instruments reports incompatible devices - for example, an iOS 11
+  # device can appear when the active Xcode is 8.3.3.  Targeting an
+  # an incompatible will cause xcodebuild to fail immediately or hang
+  # indefinitely.  Filtering devices by compatible version is tedious
+  # in any language and doublely so in bash.  Will choose the first
+  # device in the list for now.
+  echo $devices | head -1 | grep -E -o "[a-f0-9]{40}" | tr -d "\n"
+}

--- a/bin/simctl.sh
+++ b/bin/simctl.sh
@@ -2,11 +2,35 @@
 
 set +e
 
+source bin/log.sh
+
 # Force Xcode 8 CoreSimulator env to be loaded so xcodebuild does not fail.
 
 function ensure_valid_core_sim_service {
+  info "Ensuring there is a valid CoreSimulatorService"
 	for try in {1..4}; do
-		xcrun simctl help &>/dev/null
-		sleep 1.0
+    local valid=$(valid_core_sim_service)
+    if [ "${valid}" = "false" ]; then
+      info "Trying again to ensure valid CoreSimulatorService"
+      sleep 1.0
+    else
+      info "CoreSimulatorService is valid"
+      break
+    fi
 	done
+}
+
+function valid_core_sim_service {
+  local tmp_file=$(mktemp)
+  xcrun simctl help >> "${tmp_file}"
+
+  if [ "$?" != "0" ]; then
+    echo -n "false"
+  elif grep -q "Failed to location valid instance of CoreSimulatorService" "${tmp_file}"; then
+    echo -n "false"
+  elif grep -q "CoreSimulatorService connection became invalid" "${tmp_file}"; then
+    echo -n "false"
+  else
+    echo -n "true"
+  fi
 }

--- a/bin/standalone-xcuitest/test-app.sh
+++ b/bin/standalone-xcuitest/test-app.sh
@@ -1,0 +1,179 @@
+#!/usr/bin/env bash
+
+if [ "${1}" == "" ]; then
+  echo ""
+  echo "Run arbitrary XCUITests against any .app"
+  echo ""
+  echo "Usage:"
+  echo ""
+  echo "$0 path/to/AUT.app [simulator or device UDID]"
+  echo ""
+  echo "* .ipa archives must be expanded."
+  echo "* If no UDID is provided, a default will be used."
+  echo "* Tests targeting a physical device require the .app"
+  echo "  is signed for the device.  The app will be installed"
+  echo "  on the device as part of the xcodebuild command."
+  exit 0
+fi
+
+source bin/log.sh
+source bin/ditto.sh
+source bin/simctl.sh
+source bin/instruments.sh
+
+ensure_valid_core_sim_service
+
+banner "Preparing"
+
+APP="${1}"
+
+if [ ! -d "${APP}" ] || [ "${APP: -4}" != ".app" ]; then
+  error "Expected .app bundle to exist at path:"
+  error "  ${1}"
+  exit 1
+fi
+
+INFOPLIST="${APP}/Info.plist"
+
+if [ ! -e "${INFOPLIST}" ]; then
+  error "Expected Info.plist to exist at path:"
+  error "  ${INFOPLIST}"
+  exit 1
+fi
+
+EXEC_NAME=$(/usr/libexec/PlistBuddy -c "Print :CFBundleExecutable" "${INFOPLIST}" | tr -d '\n')
+EXEC_PATH="${APP}/${EXEC_NAME}"
+
+if [ "${EXEC_NAME}" = "" ]; then
+  error "Expected Info.plist to contain key CFBundleExecutable"
+  error "  ${INFOPLIST}"
+  exit 1
+fi
+
+if [ ! -e "${EXEC_PATH}" ]; then
+  error "Expected .app bundle to contain executable file:"
+  error "  ${EXEC_PATH}"
+  exit 1
+fi
+
+AUT_APP_BUNDLE=$(basename "${APP}" | tr -d '\n')
+
+LIPO_ARCHES=$(
+xcrun lipo -info "${EXEC_PATH}" | \
+  cut -d":" -f3 | awk '{$1=$1};1'
+)
+
+XC_SCHEME="StandAloneUITests"
+XC_TARGET="StandAloneUITests"
+XC_WORKSPACE="DeviceAgent.xcworkspace"
+XC_CONFIG=Debug
+
+if [[ "${LIPO_ARCHES}" =~ "arm" ]]; then
+  ARCHS="armv7 armv7s arm64"
+  XC_BUILD_DIR="build/standalone-xcuitest/arm"
+  INSTALL_DIR=Products/ipa/standalone-xcuitest
+  BUILD_PRODUCTS_DIR="${XC_BUILD_DIR}/Build/Products/${XC_CONFIG}-iphoneos"
+  SDK="iphoneos"
+  info "AUT was built for arm devices"
+else
+  ARCHS="i386 x86_64"
+  XC_BUILD_DIR="build/standalone-xcuitest/x86"
+  INSTALL_DIR=Products/app/standalone-xcuitest
+  BUILD_PRODUCTS_DIR="${XC_BUILD_DIR}/Build/Products/${XC_CONFIG}-iphonesimulator"
+  SDK="iphonesimulator"
+  info "AUT was built for x86 simulators"
+fi
+
+UDID="${2}"
+if [ "${SDK}" = "iphoneos" ]; then
+  if [ "${2}" = "" ]; then
+    UDID=$(default_device_udid)
+  fi
+
+  if [ "${UDID}" = "" ]; then
+    error "Could not find any iOS devices connected via USB"
+    error "Does the device appear in the Xcode Devices window without errors?"
+    exit 1
+  fi
+else
+  if [ "${2}" = "" ]; then
+    UDID=$(default_sim_udid)
+  fi
+fi
+
+info "Will run tests on device $UDID"
+
+hash xcpretty 2>/dev/null
+if [ $? -eq 0 ] && [ "${XCPRETTY}" != "0" ]; then
+  XC_PIPE='xcpretty -c'
+else
+  XC_PIPE='cat'
+fi
+
+info "Will pipe xcodebuild to: ${XC_PIPE}"
+
+set -e -o pipefail
+
+mkdir -p "${XC_BUILD_DIR}"
+
+rm -rf "${INSTALL_DIR}"
+mkdir -p "${INSTALL_DIR}"
+
+RUNNER=StandAloneUITests-Runner.app
+INSTALLED_RUNNER="${INSTALL_DIR}/${RUNNER}"
+INSTALLED_AUT="${INSTALL_DIR}/${AUT_APP_BUNDLE}"
+
+info "Prepared install directory ${INSTALL_DIR}"
+
+BUILD_PRODUCTS_RUNNER="${BUILD_PRODUCTS_DIR}/${RUNNER}"
+
+mkdir -p "${BUILD_PRODUCTS_DIR}"
+
+info "Prepared build directory ${XC_BUILD_DIR}"
+
+banner "Building ${RUNNER}"
+
+COMMAND_LINE_BUILD=1 \
+  xcrun xcodebuild  \
+  -SYMROOT="${XC_BUILD_DIR}" \
+  -OBJROOT="${XC_BUILD_DIR}" \
+  -derivedDataPath "${XC_BUILD_DIR}" \
+  -scheme "${XC_SCHEME}" \
+  -workspace "${XC_WORKSPACE}" \
+  -configuration "${XC_CONFIG}" \
+  -sdk "${SDK}" \
+  ARCHS="${ARCHS}" \
+  VALID_ARCHS="${ARCHS}" \
+  ONLY_ACTIVE_ARCH=NO \
+  build-for-testing | $XC_PIPE
+
+info "Building app succeeded."
+
+banner "Installing Artifacts"
+
+install_with_ditto "${BUILD_PRODUCTS_RUNNER}" "${INSTALLED_RUNNER}"
+install_with_ditto "${APP}" "${INSTALLED_AUT}"
+
+info "Installing resolved.xctestrun"
+
+TEMPLATE=StandAloneUITests/template.xctestrun
+XCTESTRUN="${INSTALL_DIR}/resolved.xctestrun"
+
+sed -e \
+  's@__RUNNER__@'"${RUNNER}"'@g;s@__AUT_APP__@'"${AUT_APP_BUNDLE}"'@g' \
+  "${TEMPLATE}" > "${XCTESTRUN}"
+
+cat $XCTESTRUN
+
+#-xctestrun MyTestRun.xctestrun -destination
+#'platform=iOS Simulator,name=iPhone 5s'
+#
+#  -SYMROOT="${XC_BUILD_DIR}" \
+#  -OBJROOT="${XC_BUILD_DIR}" \
+#  -derivedDataPath "${XC_BUILD_DIR}" \
+COMMAND_LINE_BUILD=1 \
+  xcrun xcodebuild  \
+  -xctestrun "${XCTESTRUN}" \
+  -sdk "${SDK}" \
+  -destination "id=$UDID" \
+  test-without-building | $XC_PIPE

--- a/bin/xcode.sh
+++ b/bin/xcode.sh
@@ -1,9 +1,27 @@
 
+source bin/log.sh
+
+function xcode_version {
+  xcrun xcodebuild -version | \
+    grep -E "(\d+\.\d+(\.\d+)?)" | cut -f2- -d" " | \
+    tr -d "\n"
+}
+
 function xcode_gte_9 {
- XC_MAJOR=`xcrun xcodebuild -version | awk 'NR==1{print $2}' | awk -v FS="." '{ print $1 }'`
- if [ "${XC_MAJOR}" \> "9" -o "${XC_MAJOR}" = "9" ]; then
-   echo "true"
- else
-   echo "false"
- fi
+  local version=$(xcode_version)
+  local major=$(echo $version | cut -d. -f1)
+  if [ "${major}" \> "9" -o "${major}" = "9" ]; then
+    echo -n "true"
+  else
+    echo -n "false"
+  fi
+}
+
+function simulator_app_path {
+  if [ "${DEVELOPER_DIR}" = "" ]; then
+    local dev_dir=$(xcode-select --print-path)
+  else
+    local dev_dir="${DEVELOPER_DIR}"
+  fi
+  echo -n "${dev_dir}/Applications/Simulator.app"
 }


### PR DESCRIPTION
### Motivation

While debugging iOS 11 drag-and-drop, I leveraged this technique.

Now you can too.

```
$ bin/standalone-xcuitest/test-app.sh 

Run arbitrary XCUITests against any .app

Usage:

bin/standalone-xcuitest/test-app.sh path/to/AUT.app [simulator or device UDID]

* .ipa archives must be expanded.
* If no UDID is provided, a default will be used.
* Tests targeting a physical device require the .app is signed for the device.  The app will be installed on the device as part of the xcodebuild command.
```