### PR TITLE
Add new iPhone 10S, 10S Max, and 10R model numbers

### DIFF
--- a/Server/Utilities/CBXDevice.m
+++ b/Server/Utilities/CBXDevice.m
@@ -244,7 +244,7 @@ NSString *const CBXDeviceSimKeyVersionInfo = @"SIMULATOR_VERSION_INFO";
       @"iPhone9,2" : @"iphone 6+",
       @"iPhone9,4" : @"iphone 6+",
 
-      // iPhone 8/8+/X - derived from Simulator
+      // iPhone 8/8+/X
       @"iPhone10,1" : @"iphone 6",
       @"iPhone10,4" : @"iphone 6",
       @"iPhone10,5" : @"iphone 6+",

--- a/Server/Utilities/CBXDevice.m
+++ b/Server/Utilities/CBXDevice.m
@@ -253,9 +253,9 @@ NSString *const CBXDeviceSimKeyVersionInfo = @"SIMULATOR_VERSION_INFO";
       @"iPhone10,6" : @"iphone 10",
 
       // iPhone XS/XS Max/XR - derived from Simulator
-      @"iPhone11,2" : @"iPhone11,2",
-      @"iPhone11,4" : @"iPhone11,4",
-      @"iPhone11,8" : @"iPhone11,8",
+      @"iPhone11,2" : @"iphone 10",
+      @"iPhone11,4" : @"iphone 10s max",
+      @"iPhone11,8" : @"iphone 10r",
 
       // iPad Pro 13in
       @"iPad6,7" : @"ipad pro",

--- a/Server/Utilities/CBXDevice.m
+++ b/Server/Utilities/CBXDevice.m
@@ -252,6 +252,11 @@ NSString *const CBXDeviceSimKeyVersionInfo = @"SIMULATOR_VERSION_INFO";
       @"iPhone10,3" : @"iphone 10",
       @"iPhone10,6" : @"iphone 10",
 
+      // iPhone XS/XS Max/XR - derived from Simulator
+      @"iPhone11,2" : @"iPhone11,2",
+      @"iPhone11,4" : @"iPhone11,4",
+      @"iPhone11,8" : @"iPhone11,8",
+
       // iPad Pro 13in
       @"iPad6,7" : @"ipad pro",
       @"iPad6,8" : @"ipad pro",


### PR DESCRIPTION
Added new devices in formFactorMap. Data comes from simulators via calabash-ios gem.

Related PR: https://github.com/calabash/calabash-ios-server/pull/431