### PR TITLE
Fix SafariWebController test fails for iPhone XR and XS Max.

### DIFF
--- a/cucumber/features/steps/webview.rb
+++ b/cucumber/features/steps/webview.rb
@@ -25,6 +25,12 @@ And(/^I scroll down to the first and last name text fields$/) do
   if @safari_controller
     start_point = point_for_full_pan_start(:up, {type: "WebView", all: true})
     end_point = point_for_full_pan_end(:up, {type: "WebView", all: true})
+
+    # Scroll the less 100 pixels of screen for iPhone XR and XS Max
+    if ["iphone 10r", "iphone 10s max"].include?(device_info["form_factor"])
+      end_point[:y] = end_point[:y] + 100
+    end
+
     pan_between_coordinates(start_point, end_point)
   else
     scroll_to(:up, "landing page", "Last name:", 5, true)

--- a/cucumber/features/steps/webview.rb
+++ b/cucumber/features/steps/webview.rb
@@ -26,7 +26,6 @@ And(/^I scroll down to the first and last name text fields$/) do
     start_point = point_for_full_pan_start(:up, {type: "WebView", all: true})
     end_point = point_for_full_pan_end(:up, {type: "WebView", all: true})
 
-    # Scroll the less 100 pixels of screen for iPhone XR and XS Max
     if ["iphone 10r", "iphone 10s max"].include?(device_info["form_factor"])
       end_point[:y] = end_point[:y] + 100
     end


### PR DESCRIPTION
[VSTS](https://msmobilecenter.visualstudio.com/Mobile-Center/_workitems/edit/56139)
# Description
Scenario "Interacting with SafariWebController" fails. 
This issue reproduces on physical device XS Max (iOS 12.1.3 beta 4) and simulator XS Max (12.1), but doesn't reproduce on simulator XS(12.1) and physical device XS(12.0.1). It is caused by display size.

![image](https://user-images.githubusercontent.com/40772628/53412285-00c3da80-39da-11e9-857c-40718fbfe038.png)
# Fix
The iPhone XR and XS Max have display sizes more than 6 inch. When scrolling from bottom to top of the screen the “Last name” text field is skipped and test fails. To fix the test scrolling should be started 100px higher than display bottom.
Added [condition as for iPhone 4.](https://github.com/calabash/DeviceAgent.iOS/blob/dfc14ebb0c9e7e2ca0219600eb773e23055321e9/cucumber/features/steps/webview.rb#L36)