### PR TITLE
Rename Calabash.keychain to TestCloudDev.keychain

### DIFF
--- a/CLASS_DUMP.md
+++ b/CLASS_DUMP.md
@@ -15,7 +15,7 @@ This script requires 'class-dump' to be in your PATH.
 * http://stevenygard.com/projects/class-dump/
 * https://github.com/nygard/class-dump
 
-Remember that maintainers need to use the Calabash.keychain.
+Remember that maintainers need to use the TestCloudDev.keychain.
 Non-maintainers will need to update the code signing attributes from the
 Xcode UI.
 

--- a/Makefile
+++ b/Makefile
@@ -57,10 +57,6 @@ docs:
 	bin/make/docs.sh
 
 # Installs DeviceAgent onto your machine
-#
-# Builds DeviceAgent for Sim and Device, installs to
-# ~/.test-cloud-dev/DeviceAgent/simulator and
-# ~/.test-cloud-dev/DeviceAgent/device
 install:
 	bin/install/device_agent.sh
 

--- a/Makefile
+++ b/Makefile
@@ -59,8 +59,8 @@ docs:
 # Installs DeviceAgent onto your machine
 #
 # Builds DeviceAgent for Sim and Device, installs to
-# ~/.calabash/DeviceAgent/simulator and
-# ~/.calabash/DeviceAgent/device
+# ~/.test-cloud-dev/DeviceAgent/simulator and
+# ~/.test-cloud-dev/DeviceAgent/device
 install:
 	bin/install/device_agent.sh
 

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ iPhone Developer: ambiguous matches
 ```
 
 Ambiguous matches usually mean that the certs are contained in both your
-login.keychain and the Calabash.keychain.  Delete the certs in your
+login.keychain and the TestCloudDev.keychain.  Delete the certs in your
 login.keychain.
 
 ### Contributing

--- a/TESTING.md
+++ b/TESTING.md
@@ -20,7 +20,7 @@ $ tree -L 2 -d
 
 ### TODO
 
-1. pull git@github.com:calabash/calabash-codesign.git to ~/.test-cloud-dev/test-cloud-dev-ios-keychain
+1. pull git@github.com:calabash/calabash-codesign.git
 2. pull git@github.com:calabash/iOSDeviceManager.git and checkout develop
 3. pull git@github.com:calabash/DeviceAgent.iOS.git and checkout develop
 4. pull git@github.com:calabash/run_loop.git and checkout develop
@@ -31,7 +31,7 @@ $ tree -L 2 -d
 This is required to build the Xcode project which have hard-wired code signing requirements.
 
 ```
-$ ~/.test-cloud-dev/test-cloud-dev-ios-keychain/apple/create-keychain.sh
+$ <calabash-codesign-repo>/apple/create-keychain.sh
 ```
 
 Output like this is normal:
@@ -112,7 +112,7 @@ Edit `cucumber/features/support/01_launch.rb`:
 
 When running with `xcodebuild` you will need to manually update the
 DeviceAgent.iOS Xcode code signing settings for the AppStub target
- _if_ your device is not in `test-cloud-dev-ios-keychain` provisioning profiles.
+ _if_ your device is not in `calabash-codesign` provisioning profiles.
 
 ### Log Files
 
@@ -121,7 +121,7 @@ DeviceAgent.iOS Xcode code signing settings for the AppStub target
 $ run-loop simctl tail
 
 # Available after first iOSDeviceManager command is run.
-$ tail -F ~/.test-cloud-dev/iOSDeviceManager/logs/current.log
+$ tail -F ~/.calabash/iOSDeviceManager/logs/current.log
 
 # Available after first `xcodebuild` cucumber run.
 $ tail -F ~/.run-loop/xcuitest/xcodebuild.log

--- a/TESTING.md
+++ b/TESTING.md
@@ -20,18 +20,18 @@ $ tree -L 2 -d
 
 ### TODO
 
-1. pull git@github.com:calabash/calabash-codesign.git to ~/.calabash/calabash-codesign
+1. pull git@github.com:calabash/calabash-codesign.git to ~/.test-cloud-dev/test-cloud-dev-ios-keychain
 2. pull git@github.com:calabash/iOSDeviceManager.git and checkout develop
 3. pull git@github.com:calabash/DeviceAgent.iOS.git and checkout develop
 4. pull git@github.com:calabash/run_loop.git and checkout develop
 5. Configure bundler to use local run_loop: `$ bundle config local.run_loop /path/to/run_loop`
 
-### Create Calabash.keychain
+### Create TestCloudDev.keychain
 
 This is required to build the Xcode project which have hard-wired code signing requirements.
 
 ```
-$ ~/.calabash/calabash-codesign/apple/create-keychain.sh
+$ ~/.test-cloud-dev/test-cloud-dev-ios-keychain/apple/create-keychain.sh
 ```
 
 Output like this is normal:
@@ -112,7 +112,7 @@ Edit `cucumber/features/support/01_launch.rb`:
 
 When running with `xcodebuild` you will need to manually update the
 DeviceAgent.iOS Xcode code signing settings for the AppStub target
- _if_ your device is not in `calabash-codesign` provisioning profiles.
+ _if_ your device is not in `test-cloud-dev-ios-keychain` provisioning profiles.
 
 ### Log Files
 
@@ -121,7 +121,7 @@ DeviceAgent.iOS Xcode code signing settings for the AppStub target
 $ run-loop simctl tail
 
 # Available after first iOSDeviceManager command is run.
-$ tail -F ~/.calabash/iOSDeviceManager/logs/current.log
+$ tail -F ~/.test-cloud-dev/iOSDeviceManager/logs/current.log
 
 # Available after first `xcodebuild` cucumber run.
 $ tail -F ~/.run-loop/xcuitest/xcodebuild.log

--- a/bin/ci/appcenter.sh
+++ b/bin/ci/appcenter.sh
@@ -18,7 +18,7 @@ else
 fi
 set -e
 
-KEYCHAIN="${HOME}/.test-cloud-dev/TestCloudDev.keychain"
+KEYCHAIN="${HOME}/Library/Keychains/test-cloud-dev/TestCloudDev.keychain-db"
 
 if [ ! -e "${KEYCHAIN}" ]; then
   echo "Cannot find S3 credentials: there is no TestCloudDev.keychain"
@@ -26,21 +26,21 @@ if [ ! -e "${KEYCHAIN}" ]; then
   exit 1
 fi
 
-if [ ! -e "${HOME}/.test-cloud-dev/find-keychain-credential.sh" ]; then
+if [ ! -e "${HOME}/Library/Keychains/test-cloud-dev/find-keychain-credential.sh" ]; then
   echo "Cannot find S3 credentials: no find-keychain-credential.sh script"
-  echo "  ${HOME}/.test-cloud-dev/find-keychain-credential.sh"
+  echo "  ${HOME}/Library/Keychains/test-cloud-dev/find-keychain-credential.sh"
   exit 1
 fi
 
 export AWS_ACCESS_KEY_ID=$(
-"${HOME}/.test-cloud-dev/find-keychain-credential.sh" s3-access-key
+"${HOME}/Library/Keychains/test-cloud-dev/find-keychain-credential.sh" s3-access-key
 )
 export AWS_SECRET_ACCESS_KEY=$(
-"${HOME}/.test-cloud-dev/find-keychain-credential.sh" s3-secret
+"${HOME}/Library/Keychains/test-cloud-dev/find-keychain-credential.sh" s3-secret
 )
 
 if [ "${AC_TOKEN}" = "" ]; then
-  AC_TOKEN=$("${HOME}/.test-cloud-dev/find-keychain-credential.sh" api-token)
+  AC_TOKEN=$("${HOME}/Library/Keychains/test-cloud-dev/find-keychain-credential.sh" api-token)
 fi
 
 IPA=Products/ipa/DeviceAgent/DeviceAgent-Runner.ipa

--- a/bin/ci/appcenter.sh
+++ b/bin/ci/appcenter.sh
@@ -18,29 +18,29 @@ else
 fi
 set -e
 
-KEYCHAIN="${HOME}/.calabash/Calabash.keychain"
+KEYCHAIN="${HOME}/.test-cloud-dev/TestCloudDev.keychain"
 
 if [ ! -e "${KEYCHAIN}" ]; then
-  echo "Cannot find S3 credentials: there is no Calabash.keychain"
+  echo "Cannot find S3 credentials: there is no TestCloudDev.keychain"
   echo "  ${KEYCHAIN}"
   exit 1
 fi
 
-if [ ! -e "${HOME}/.calabash/find-keychain-credential.sh" ]; then
+if [ ! -e "${HOME}/.test-cloud-dev/find-keychain-credential.sh" ]; then
   echo "Cannot find S3 credentials: no find-keychain-credential.sh script"
-  echo "  ${HOME}/.calabash/find-keychain-credential.sh"
+  echo "  ${HOME}/.test-cloud-dev/find-keychain-credential.sh"
   exit 1
 fi
 
 export AWS_ACCESS_KEY_ID=$(
-"${HOME}/.calabash/find-keychain-credential.sh" s3-access-key
+"${HOME}/.test-cloud-dev/find-keychain-credential.sh" s3-access-key
 )
 export AWS_SECRET_ACCESS_KEY=$(
-"${HOME}/.calabash/find-keychain-credential.sh" s3-secret
+"${HOME}/.test-cloud-dev/find-keychain-credential.sh" s3-secret
 )
 
 if [ "${AC_TOKEN}" = "" ]; then
-  AC_TOKEN=$("${HOME}/.calabash/find-keychain-credential.sh" api-token)
+  AC_TOKEN=$("${HOME}/.test-cloud-dev/find-keychain-credential.sh" api-token)
 fi
 
 IPA=Products/ipa/DeviceAgent/DeviceAgent-Runner.ipa

--- a/bin/make/gemuse-libs.sh
+++ b/bin/make/gemuse-libs.sh
@@ -73,7 +73,7 @@ function fat_lib_with_lipo {
   xcrun lipo -create "${arm_lib}" "${sim_lib}" \
     -output "${fat_lib}"
 
-  "${HOME}/.calabash/calabash-codesign/apple/resign-dylib.sh" \
+  "${HOME}/.test-cloud-dev/test-cloud-dev-ios-keychain/apple/resign-dylib.sh" \
     "${fat_lib}"
 
   local version=$(xcrun strings "${fat_lib}" | \

--- a/bin/make/gemuse-libs.sh
+++ b/bin/make/gemuse-libs.sh
@@ -73,7 +73,7 @@ function fat_lib_with_lipo {
   xcrun lipo -create "${arm_lib}" "${sim_lib}" \
     -output "${fat_lib}"
 
-  "${HOME}/.test-cloud-dev/test-cloud-dev-ios-keychain/apple/resign-dylib.sh" \
+  "${HOME}/.calabash/calabash-codesign/apple/resign-dylib.sh" \
     "${fat_lib}"
 
   local version=$(xcrun strings "${fat_lib}" | \


### PR DESCRIPTION
[User Story 63322: rename calabash-codesign and Calabash.key to TestCloudDev.keychain](https://msmobilecenter.visualstudio.com/Mobile-Center/_workitems/edit/63322)