### PR TITLE
Fix XCTestRun Bundle Id on Xcode 11.0

### DIFF
--- a/DeviceAgent/DeviceAgent-device.xctestrun
+++ b/DeviceAgent/DeviceAgent-device.xctestrun
@@ -9,7 +9,7 @@
 		<key>TestBundleDestinationRelativePath</key>
 		<string>__TESTHOST__/PlugIns/DeviceAgent.xctest</string>
 		<key>TestHostBundleIdentifier</key>
-		<string>com.apple.test.DeviceAgent-Runner</string>
+		<string>sh.calaba.DeviceAgent.xctrunner</string>
 		<key>TestingEnvironmentVariables</key>
 		<dict>
 			<key>DYLD_FRAMEWORK_PATH</key>

--- a/bin/patch-runner-info-plist.sh
+++ b/bin/patch-runner-info-plist.sh
@@ -84,6 +84,13 @@ info "Syncing $(basename ${DEVICE_AGENT}) version"
 plist_set_key "${DEVICE_AGENT_PLIST}" "CFBundleVersion" "${BUNDLE_VERSION}"
 plist_set_key "${DEVICE_AGENT_PLIST}" "CFBundleShortVersionString" "${SHORT_VERSION}"
 
+if [ "$(xcode_gte_11)" = "false" ]; then
+  banner "Patching DeviceAgent-device.xctestrun"
+  DEVICE_AGENT_XCTESTRUN="${DEVICE_AGENT}/DeviceAgent-device.xctestrun"
+  info "${DEVICE_AGENT_XCTESTRUN}"
+  plist_set_key "${DEVICE_AGENT_XCTESTRUN}" "TestTargetName:TestHostBundleIdentifier" "com.apple.test.DeviceAgent-Runner"
+fi
+
 banner "Resigning"
 
 if [ "$(xcode_gte_9)" = "true" ]; then

--- a/bin/xcode.sh
+++ b/bin/xcode.sh
@@ -31,6 +31,16 @@ function xcode_gte_93 {
   fi
 }
 
+function xcode_gte_11 {
+  local version=$(xcode_version)
+  local major=$(echo $version | cut -d. -f1)
+  if (( ${major} >= 11 )); then
+    echo -n "true"
+  else
+    echo -n "false"
+  fi
+}
+
 function simulator_app_path {
   if [ "${DEVELOPER_DIR}" = "" ]; then
     local dev_dir=$(xcode-select --print-path)


### PR DESCRIPTION
Xcode 11 changed logic to generate bundle Id for `build-for-testing` build.
- Xcode 10.2.1 produces bundle Id `com.apple.test.DeviceAgent-Runner` (`com.apple.test.<PRODUCT_NAME>`)
- Xcode 11 produces bundle id `sh.calaba.DeviceAgent.xctrunner` (`<PRODUCT_BUNDLE_ID>.xctrunner`)


**Changes:**
- Change bundle id  in `DeviceAgent/DeviceAgent-device.xctestrun` to `sh.calaba.DeviceAgent.xctrunner`
- add logic to `bin/patch-runner-info-plist.sh` to change `DeviceAgent-device.xctestrun` and set `TestHostBundleIdentifier` to `com.apple.test.DeviceAgent-Runner` for Xcode versions < 11.0
