### PR TITLE
Fix statusBar tests

### DIFF
--- a/TestApp/App/Base.lproj/Main.storyboard
+++ b/TestApp/App/Base.lproj/Main.storyboard
@@ -99,9 +99,7 @@
                                 <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <constraints>
                                     <constraint firstItem="ySD-iS-omE" firstAttribute="top" secondItem="N1v-YP-Pj5" secondAttribute="bottom" constant="8" id="0rU-R7-TUt"/>
-                                    <constraint firstItem="6xi-u4-e9s" firstAttribute="top" secondItem="N1v-YP-Pj5" secondAttribute="bottom" constant="8" id="3mV-bm-kfc"/>
                                     <constraint firstAttribute="width" constant="238" id="7EY-8a-cky"/>
-                                    <constraint firstItem="6xi-u4-e9s" firstAttribute="leading" secondItem="ySD-iS-omE" secondAttribute="trailing" constant="12" id="ImN-Dz-dgX"/>
                                     <constraint firstItem="Inb-f1-nFB" firstAttribute="leading" secondItem="6xi-u4-e9s" secondAttribute="trailing" constant="10" id="M8B-Hm-ozg"/>
                                     <constraint firstAttribute="trailing" secondItem="Inb-f1-nFB" secondAttribute="trailing" constant="8" id="XuN-G4-Ceg"/>
                                     <constraint firstItem="OhG-EI-aLB" firstAttribute="centerX" secondItem="7sx-D5-q7V" secondAttribute="centerX" id="col-4V-cOa"/>
@@ -113,7 +111,6 @@
                                     <constraint firstItem="Inb-f1-nFB" firstAttribute="top" secondItem="N1v-YP-Pj5" secondAttribute="bottom" constant="8" id="eNL-gy-td2"/>
                                     <constraint firstAttribute="height" constant="142" id="gvl-Je-fPl"/>
                                     <constraint firstItem="N1v-YP-Pj5" firstAttribute="top" secondItem="7sx-D5-q7V" secondAttribute="top" constant="8" id="nwo-fZ-EnS"/>
-                                    <constraint firstItem="6xi-u4-e9s" firstAttribute="leading" secondItem="ySD-iS-omE" secondAttribute="trailing" constant="12" id="oYY-Jh-W5N"/>
                                     <constraint firstItem="ySD-iS-omE" firstAttribute="leading" secondItem="7sx-D5-q7V" secondAttribute="leading" constant="8" id="q7x-xJ-FV8"/>
                                 </constraints>
                                 <variation key="default">

--- a/TestApp/App/Base.lproj/Main.storyboard
+++ b/TestApp/App/Base.lproj/Main.storyboard
@@ -1,29 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13771" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="49e-Tb-3d3">
-    <device id="retina4_7" orientation="portrait">
-        <adaptation id="fullscreen"/>
-    </device>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14845" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="49e-Tb-3d3">
+    <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13772"/>
-        <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14799.2"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
-    <customFonts key="customFonts">
-        <array key="Avenir.ttc">
-            <string>Avenir-Book</string>
-            <string>Avenir-Medium</string>
-        </array>
-        <array key="GurmukhiMN.ttc">
-            <string>GurmukhiMN</string>
-        </array>
-        <array key="HoeflerText.ttc">
-            <string>HoeflerText-Regular</string>
-        </array>
-        <array key="Optima.ttc">
-            <string>Optima-Regular</string>
-        </array>
-    </customFonts>
     <scenes>
         <!--Touch-->
         <scene sceneID="hNz-n2-bh7">
@@ -48,7 +30,7 @@
                                 <rect key="frame" x="16" y="386" width="238" height="142"/>
                                 <subviews>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Silly Buttons" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="N1v-YP-Pj5">
-                                        <rect key="frame" x="72" y="8" width="95" height="21"/>
+                                        <rect key="frame" x="71.5" y="8" width="95" height="21"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="21" id="Cgc-Z6-1uZ"/>
                                             <constraint firstAttribute="width" constant="95" id="LZ6-JM-dSE"/>
@@ -141,7 +123,7 @@
                                 </variation>
                             </view>
                             <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="MnM-k1-4At">
-                                <rect key="frame" x="259" y="254" width="51" height="31"/>
+                                <rect key="frame" x="314" y="441" width="51" height="31"/>
                                 <accessibility key="accessibilityConfiguration" identifier="switch"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="31" id="EDb-zy-e0Y"/>
@@ -152,7 +134,7 @@
                                 </connections>
                             </switch>
                             <segmentedControl opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="top" segmentControlStyle="plain" selectedSegmentIndex="0" translatesAutoresizingMaskIntoConstraints="NO" id="CG1-wS-k0E">
-                                <rect key="frame" x="16" y="163" width="288" height="29"/>
+                                <rect key="frame" x="16" y="347" width="288" height="32"/>
                                 <constraints>
                                     <constraint firstAttribute="width" constant="288" id="smz-It-1eK"/>
                                 </constraints>
@@ -188,6 +170,8 @@
                         <outlet property="gestureLabel" destination="K2c-Gh-js7" id="aoX-9A-6MK"/>
                         <outlet property="onOffSwitch" destination="MnM-k1-4At" id="G8t-r8-KNN"/>
                         <outlet property="zeroButton" destination="6xi-u4-e9s" id="mM7-Zp-89q"/>
+                        <outlet property="zeroButtonHeightConstraint" destination="ZLL-n6-n7H" id="AXK-h7-HuL"/>
+                        <outlet property="zeroButtonWidthConstraint" destination="rIU-6L-fZ0" id="Wdy-XD-oLK"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="W5J-7L-Pyd" sceneMemberID="firstResponder"/>
@@ -207,7 +191,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Wie geht's?" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="p4O-xQ-Uw3">
-                                <rect key="frame" x="16" y="560" width="343" height="50"/>
+                                <rect key="frame" x="16" y="568" width="343" height="42"/>
                                 <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <fontDescription key="fontDescription" name="GurmukhiMN" family="Gurmukhi MN" pointSize="35"/>
                                 <color key="textColor" red="1" green="0.50196081400000003" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -300,7 +284,7 @@
                                 <nil key="highlightedColor"/>
                             </label>
                             <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" showsHorizontalScrollIndicator="NO" translatesAutoresizingMaskIntoConstraints="NO" id="uia-2X-sCs">
-                                <rect key="frame" x="16" y="20" width="343" height="543"/>
+                                <rect key="frame" x="16" y="0.0" width="343" height="563"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="37X-zV-EjS" userLabel="ThreeFingerTap">
                                         <rect key="frame" x="0.0" y="135" width="234" height="60"/>
@@ -481,7 +465,7 @@
                                         <rect key="frame" x="60" y="0.0" width="156" height="60"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="2-finger tap" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="I1g-am-hC1">
-                                                <rect key="frame" x="32" y="9" width="91" height="44"/>
+                                                <rect key="frame" x="32" y="9" width="91" height="43"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                 <nil key="highlightedColor"/>
@@ -589,21 +573,21 @@
                             <tableViewSection id="WwQ-ZV-70F">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" textLabel="iNu-Dn-9Si" detailTextLabel="UrV-Kg-9Hg" style="IBUITableViewCellStyleSubtitle" id="Dh1-6J-2tw" userLabel="Palette">
-                                        <rect key="frame" x="0.0" y="0.0" width="375" height="56"/>
+                                        <rect key="frame" x="0.0" y="28" width="375" height="56"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="Dh1-6J-2tw" id="SCs-a0-fED">
-                                            <rect key="frame" x="0.0" y="0.0" width="342" height="56"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="347.5" height="56"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Palette" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="iNu-Dn-9Si">
-                                                    <rect key="frame" x="15" y="12" width="50.5" height="19.5"/>
+                                                    <rect key="frame" x="16" y="9" width="50.5" height="19.5"/>
                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="16"/>
                                                     <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Trace finger movement" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="UrV-Kg-9Hg">
-                                                    <rect key="frame" x="15" y="31.5" width="121.5" height="13.5"/>
+                                                    <rect key="frame" x="16" y="31.5" width="121" height="13.5"/>
                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="11"/>
                                                     <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -617,21 +601,21 @@
                                         </connections>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" textLabel="8du-8F-5Xq" detailTextLabel="Q7B-Xg-6lC" style="IBUITableViewCellStyleSubtitle" id="lTZ-d2-DCV" userLabel="Drag and Drop">
-                                        <rect key="frame" x="0.0" y="56" width="375" height="56"/>
+                                        <rect key="frame" x="0.0" y="84" width="375" height="56"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="lTZ-d2-DCV" id="tAN-M0-Bu7">
-                                            <rect key="frame" x="0.0" y="0.0" width="342" height="56"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="347.5" height="56"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Drag and Drop" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="8du-8F-5Xq">
-                                                    <rect key="frame" x="15" y="12" width="106" height="19.5"/>
+                                                    <rect key="frame" x="16" y="9" width="106" height="19.5"/>
                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="16"/>
                                                     <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Move views around" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="Q7B-Xg-6lC">
-                                                    <rect key="frame" x="15" y="31.5" width="100.5" height="13.5"/>
+                                                    <rect key="frame" x="16" y="31.5" width="100.5" height="13.5"/>
                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="11"/>
                                                     <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -645,14 +629,14 @@
                                         </connections>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" textLabel="zFh-jv-lzm" detailTextLabel="Zfs-87-9hj" style="IBUITableViewCellStyleSubtitle" id="lB5-w8-rK1" userLabel="Everything's On the Table">
-                                        <rect key="frame" x="0.0" y="112" width="375" height="56"/>
+                                        <rect key="frame" x="0.0" y="140" width="375" height="56"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="lB5-w8-rK1" id="oyi-d0-7rq">
-                                            <rect key="frame" x="0.0" y="0.0" width="342" height="56"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="347.5" height="56"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Everything's On the Table" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="zFh-jv-lzm">
-                                                    <rect key="frame" x="15" y="12" width="185.5" height="19.5"/>
+                                                    <rect key="frame" x="16" y="9" width="185" height="19.5"/>
                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                     <accessibility key="accessibilityConfiguration" identifier="table"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="16"/>
@@ -660,7 +644,7 @@
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Swipe to delete, scroll, flick, and reorder" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="Zfs-87-9hj">
-                                                    <rect key="frame" x="15" y="31.5" width="212.5" height="13.5"/>
+                                                    <rect key="frame" x="16" y="31.5" width="212.5" height="13.5"/>
                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="11"/>
                                                     <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -674,21 +658,21 @@
                                         </connections>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" textLabel="eCp-qc-o6q" detailTextLabel="yyu-9d-PEN" style="IBUITableViewCellStyleSubtitle" id="pzm-XV-vkW" userLabel="Paging Doctor Octagon">
-                                        <rect key="frame" x="0.0" y="168" width="375" height="56"/>
+                                        <rect key="frame" x="0.0" y="196" width="375" height="56"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="pzm-XV-vkW" id="21M-EN-pOg">
-                                            <rect key="frame" x="0.0" y="0.0" width="342" height="56"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="347.5" height="56"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Paging Doctor Octagon" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="eCp-qc-o6q">
-                                                    <rect key="frame" x="15" y="12" width="170" height="19.5"/>
+                                                    <rect key="frame" x="16" y="9" width="170" height="19.5"/>
                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="16"/>
                                                     <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Swipe to change page" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="yyu-9d-PEN">
-                                                    <rect key="frame" x="15" y="31.5" width="116.5" height="13.5"/>
+                                                    <rect key="frame" x="16" y="31.5" width="116.5" height="13.5"/>
                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="11"/>
                                                     <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -699,21 +683,21 @@
                                         <accessibility key="accessibilityConfiguration" identifier="paging row"/>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" textLabel="HOa-bC-G0P" detailTextLabel="KUH-Lc-S3e" style="IBUITableViewCellStyleSubtitle" id="INU-kM-Sd1" userLabel="Scrollplications">
-                                        <rect key="frame" x="0.0" y="224" width="375" height="56"/>
+                                        <rect key="frame" x="0.0" y="252" width="375" height="56"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="INU-kM-Sd1" id="7gC-xc-Mbe">
-                                            <rect key="frame" x="0.0" y="0.0" width="342" height="56"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="347.5" height="56"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Scrollplications" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="HOa-bC-G0P">
-                                                    <rect key="frame" x="15" y="12" width="110" height="19.5"/>
+                                                    <rect key="frame" x="16" y="9" width="110" height="19.5"/>
                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="16"/>
                                                     <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Move around a scrolling view" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="KUH-Lc-S3e">
-                                                    <rect key="frame" x="15" y="31.5" width="152" height="13.5"/>
+                                                    <rect key="frame" x="16" y="31.5" width="152" height="13.5"/>
                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="11"/>
                                                     <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -1056,7 +1040,7 @@
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <label opaque="NO" tag="3030" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Company name" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsLetterSpacingToFitWidth="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="gKX-WA-qeZ">
-                                            <rect key="frame" x="76" y="18" width="275" height="24"/>
+                                            <rect key="frame" x="84" y="18" width="259" height="24"/>
                                             <constraints>
                                                 <constraint firstAttribute="height" constant="24" id="cr2-WQ-FpV"/>
                                             </constraints>
@@ -1065,7 +1049,7 @@
                                             <nil key="highlightedColor"/>
                                         </label>
                                         <imageView userInteractionEnabled="NO" tag="3031" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="Gyr-Yy-SXi">
-                                            <rect key="frame" x="20" y="9" width="40" height="40"/>
+                                            <rect key="frame" x="28" y="10" width="40" height="40"/>
                                             <constraints>
                                                 <constraint firstAttribute="height" constant="40" id="6c0-7h-llr"/>
                                                 <constraint firstAttribute="width" constant="40" id="eU3-OM-c77"/>
@@ -1099,7 +1083,7 @@
                 <navigationController id="i73-Yh-aNC" userLabel="Pan Menu" sceneMemberID="viewController">
                     <tabBarItem key="tabBarItem" title="Pan" image="tab-bar-gestures" selectedImage="tab-bar-gestures-selected" id="MWC-Y2-cbM" userLabel="Pan"/>
                     <navigationBar key="navigationBar" contentMode="scaleToFill" id="M9H-v1-Vuc">
-                        <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
                     <connections>
@@ -1123,7 +1107,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="8" adjustsLetterSpacingToFitWidth="YES" translatesAutoresizingMaskIntoConstraints="NO" id="itp-iG-vg1">
-                                <rect key="frame" x="0.0" y="104" width="375" height="18"/>
+                                <rect key="frame" x="0.0" y="84" width="375" height="18"/>
                                 <color key="backgroundColor" red="0.90196079019999997" green="0.90196079019999997" blue="0.90196079019999997" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <accessibility key="accessibilityConfiguration" identifier="text delegate"/>
                                 <constraints>
@@ -1134,7 +1118,7 @@
                                 <nil key="highlightedColor"/>
                             </label>
                             <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Schreib!" textAlignment="center" minimumFontSize="10" clearButtonMode="always" translatesAutoresizingMaskIntoConstraints="NO" id="gUN-3j-Tbv">
-                                <rect key="frame" x="0.0" y="74" width="339" height="30"/>
+                                <rect key="frame" x="0.0" y="54" width="339" height="30"/>
                                 <accessibility key="accessibilityConfiguration" identifier="text field"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="30" id="qQM-Dd-9B6"/>
@@ -1143,7 +1127,7 @@
                                 <textInputTraits key="textInputTraits"/>
                             </textField>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="L77-WD-uO0">
-                                <rect key="frame" x="339" y="74" width="36" height="30"/>
+                                <rect key="frame" x="339" y="54" width="36" height="30"/>
                                 <accessibility key="accessibilityConfiguration" identifier="clear text field button"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="30" id="WAC-yh-zEC"/>
@@ -1155,7 +1139,7 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="DJp-FR-igg" userLabel="Clear Text View Button">
-                                <rect key="frame" x="339" y="122" width="36" height="30"/>
+                                <rect key="frame" x="339" y="102" width="36" height="30"/>
                                 <accessibility key="accessibilityConfiguration" identifier="clear text view button"/>
                                 <constraints>
                                     <constraint firstAttribute="width" constant="36" id="AAo-hg-bBi"/>
@@ -1167,7 +1151,7 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="kBY-8b-gsy" userLabel="Clear Text View Button">
-                                <rect key="frame" x="0.0" y="202" width="36" height="21"/>
+                                <rect key="frame" x="0.0" y="182" width="36" height="21"/>
                                 <accessibility key="accessibilityConfiguration" identifier="clear key input button"/>
                                 <constraints>
                                     <constraint firstAttribute="width" constant="36" id="McS-dj-qNd"/>
@@ -1179,7 +1163,7 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="3DB-XL-KGR" userLabel="Dismiss Text View Keyboard">
-                                <rect key="frame" x="339" y="152" width="36" height="30"/>
+                                <rect key="frame" x="339" y="132" width="36" height="30"/>
                                 <accessibility key="accessibilityConfiguration" identifier="dismiss text view keyboard"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="30" id="iBu-Sp-46o"/>
@@ -1192,7 +1176,7 @@
                                 </connections>
                             </button>
                             <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Ça va?" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="10" adjustsLetterSpacingToFitWidth="YES" translatesAutoresizingMaskIntoConstraints="NO" id="mXs-G4-gwd">
-                                <rect key="frame" x="0.0" y="577" width="375" height="36"/>
+                                <rect key="frame" x="0.0" y="523" width="375" height="36"/>
                                 <color key="backgroundColor" red="1" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <accessibility key="accessibilityConfiguration" identifier="question"/>
                                 <constraints>
@@ -1205,7 +1189,7 @@
                                 <size key="shadowOffset" width="3" height="-1"/>
                             </label>
                             <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="CXw-ot-Afk">
-                                <rect key="frame" x="0.0" y="122" width="339" height="80"/>
+                                <rect key="frame" x="0.0" y="102" width="339" height="80"/>
                                 <color key="backgroundColor" red="0.69049358370000002" green="0.69049358370000002" blue="0.69049358370000002" alpha="1" colorSpace="calibratedRGB"/>
                                 <accessibility key="accessibilityConfiguration" identifier="text view"/>
                                 <constraints>
@@ -1216,7 +1200,7 @@
                                 <textInputTraits key="textInputTraits" autocorrectionType="no" spellCheckingType="no"/>
                             </textView>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="id&lt;UIKeyInput&gt;" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="NsS-bY-ri4" customClass="CalTextField">
-                                <rect key="frame" x="36" y="202" width="303" height="21"/>
+                                <rect key="frame" x="36" y="182" width="303" height="21"/>
                                 <color key="backgroundColor" red="0.40000000600000002" green="0.40000000600000002" blue="1" alpha="1" colorSpace="calibratedRGB"/>
                                 <accessibility key="accessibilityConfiguration" identifier="key input">
                                     <accessibilityTraits key="traits" none="YES"/>
@@ -1229,7 +1213,7 @@
                                 <nil key="highlightedColor"/>
                             </label>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="CsY-yF-dii" userLabel="Dismiss Text View Keyboard">
-                                <rect key="frame" x="339" y="202" width="36" height="21"/>
+                                <rect key="frame" x="339" y="182" width="36" height="21"/>
                                 <accessibility key="accessibilityConfiguration" identifier="dismiss key input keyboard"/>
                                 <constraints>
                                     <constraint firstAttribute="width" constant="36" id="GFX-vv-ti9"/>
@@ -1307,21 +1291,21 @@
                             <tableViewSection id="rDU-8w-Ne1">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" textLabel="GQm-vA-pWa" detailTextLabel="cwI-6o-FZ4" style="IBUITableViewCellStyleSubtitle" id="p3O-gg-OJ1" userLabel="Text Input">
-                                        <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
+                                        <rect key="frame" x="0.0" y="28" width="375" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="p3O-gg-OJ1" id="quJ-mL-8Zs">
-                                            <rect key="frame" x="0.0" y="0.0" width="342" height="44"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="347.5" height="44"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Everything in conText" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="GQm-vA-pWa">
-                                                    <rect key="frame" x="15" y="6" width="154.5" height="19.5"/>
+                                                    <rect key="frame" x="16" y="6" width="154.5" height="19.5"/>
                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="16"/>
                                                     <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Text Input Views" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="cwI-6o-FZ4">
-                                                    <rect key="frame" x="15" y="25.5" width="86.5" height="13.5"/>
+                                                    <rect key="frame" x="16" y="25.5" width="86" height="13.5"/>
                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="11"/>
                                                     <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -1335,21 +1319,21 @@
                                         </connections>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" textLabel="XYj-a1-IWa" detailTextLabel="V5p-Oa-NHL" style="IBUITableViewCellStyleSubtitle" id="xd7-FV-Wei" userLabel="Query">
-                                        <rect key="frame" x="0.0" y="44" width="375" height="44"/>
+                                        <rect key="frame" x="0.0" y="72" width="375" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="xd7-FV-Wei" id="ZUC-0Z-mBg">
-                                            <rect key="frame" x="0.0" y="0.0" width="342" height="44"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="347.5" height="44"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Asking questions, getting answers" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="XYj-a1-IWa">
-                                                    <rect key="frame" x="15" y="6" width="248" height="19.5"/>
+                                                    <rect key="frame" x="16" y="6" width="248" height="19.5"/>
                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="16"/>
                                                     <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Querying" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="V5p-Oa-NHL">
-                                                    <rect key="frame" x="15" y="25.5" width="48" height="13.5"/>
+                                                    <rect key="frame" x="16" y="25.5" width="48" height="13.5"/>
                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="11"/>
                                                     <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -1363,21 +1347,21 @@
                                         </connections>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" textLabel="8uL-XS-eSN" detailTextLabel="Y0o-jt-AgT" style="IBUITableViewCellStyleSubtitle" id="lng-bn-b4y" userLabel="Volume">
-                                        <rect key="frame" x="0.0" y="88" width="375" height="44"/>
+                                        <rect key="frame" x="0.0" y="116" width="375" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="lng-bn-b4y" id="p4P-bl-P4C">
-                                            <rect key="frame" x="0.0" y="0.0" width="342" height="44"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="347.5" height="44"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Pump Up the Volume" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="8uL-XS-eSN">
-                                                    <rect key="frame" x="15" y="6" width="153.5" height="19.5"/>
+                                                    <rect key="frame" x="16" y="6" width="153" height="19.5"/>
                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="16"/>
                                                     <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Volume Controls" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="Y0o-jt-AgT">
-                                                    <rect key="frame" x="15" y="25.5" width="86.5" height="13.5"/>
+                                                    <rect key="frame" x="16" y="25.5" width="86.5" height="13.5"/>
                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="11"/>
                                                     <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -1391,21 +1375,21 @@
                                         </connections>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" textLabel="Dgs-mc-EEd" detailTextLabel="84C-hX-PAs" style="IBUITableViewCellStyleSubtitle" id="IIT-6p-xP8" userLabel="Environment">
-                                        <rect key="frame" x="0.0" y="132" width="375" height="44"/>
+                                        <rect key="frame" x="0.0" y="160" width="375" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="IIT-6p-xP8" id="4LI-0N-Fum">
-                                            <rect key="frame" x="0.0" y="0.0" width="342" height="44"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="347.5" height="44"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Environmentally Friendly!" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="Dgs-mc-EEd">
-                                                    <rect key="frame" x="15" y="6" width="182" height="19.5"/>
+                                                    <rect key="frame" x="16" y="6" width="181.5" height="19.5"/>
                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="16"/>
                                                     <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Application Environment" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="84C-hX-PAs">
-                                                    <rect key="frame" x="15" y="25.5" width="127.5" height="13.5"/>
+                                                    <rect key="frame" x="16" y="25.5" width="127.5" height="13.5"/>
                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="11"/>
                                                     <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -1419,21 +1403,21 @@
                                         </connections>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" textLabel="UJJ-1Y-oGD" detailTextLabel="Qsy-zH-yAE" style="IBUITableViewCellStyleSubtitle" id="c3z-NG-Zjo" userLabel="Arguments">
-                                        <rect key="frame" x="0.0" y="176" width="375" height="44"/>
+                                        <rect key="frame" x="0.0" y="204" width="375" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="c3z-NG-Zjo" id="Ri0-F1-8Vi">
-                                            <rect key="frame" x="0.0" y="0.0" width="342" height="44"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="347.5" height="44"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Apps with Attitude" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="UJJ-1Y-oGD">
-                                                    <rect key="frame" x="15" y="6" width="134" height="19.5"/>
+                                                    <rect key="frame" x="16" y="6" width="134" height="19.5"/>
                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="16"/>
                                                     <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Application Arguments" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="Qsy-zH-yAE">
-                                                    <rect key="frame" x="15" y="25.5" width="119.5" height="13.5"/>
+                                                    <rect key="frame" x="16" y="25.5" width="119.5" height="13.5"/>
                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="11"/>
                                                     <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -1447,21 +1431,21 @@
                                         </connections>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" textLabel="UpN-CS-f4v" detailTextLabel="d0r-L3-nRK" style="IBUITableViewCellStyleSubtitle" id="gdI-91-VtS" userLabel="Alerts and Sheets">
-                                        <rect key="frame" x="0.0" y="220" width="375" height="44"/>
+                                        <rect key="frame" x="0.0" y="248" width="375" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="gdI-91-VtS" id="iFt-dr-ZNe">
-                                            <rect key="frame" x="0.0" y="0.0" width="342" height="44"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="347.5" height="44"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Shields up!" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="UpN-CS-f4v">
-                                                    <rect key="frame" x="15" y="6" width="80.5" height="19.5"/>
+                                                    <rect key="frame" x="16" y="6" width="80.5" height="19.5"/>
                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="16"/>
                                                     <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Alerts and sheets" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="d0r-L3-nRK">
-                                                    <rect key="frame" x="15" y="25.5" width="92" height="13.5"/>
+                                                    <rect key="frame" x="16" y="25.5" width="92" height="13.5"/>
                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="11"/>
                                                     <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -1475,14 +1459,14 @@
                                         </connections>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" textLabel="c41-bb-7MR" detailTextLabel="gI4-bl-AIn" style="IBUITableViewCellStyleSubtitle" id="QHx-q1-pWz" userLabel="UIWebView">
-                                        <rect key="frame" x="0.0" y="264" width="375" height="44"/>
+                                        <rect key="frame" x="0.0" y="292" width="375" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="QHx-q1-pWz" id="Jp7-Lx-uWT">
-                                            <rect key="frame" x="0.0" y="0.0" width="342" height="44"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="347.5" height="44"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="UIWebView" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="c41-bb-7MR">
-                                                    <rect key="frame" x="15" y="6" width="83" height="19.5"/>
+                                                    <rect key="frame" x="16" y="6" width="82.5" height="19.5"/>
                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                     <accessibility key="accessibilityConfiguration" identifier="we"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="16"/>
@@ -1490,7 +1474,7 @@
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="The rise of the WebApp." textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="gI4-bl-AIn">
-                                                    <rect key="frame" x="15" y="25.5" width="127" height="13.5"/>
+                                                    <rect key="frame" x="16" y="25.5" width="127" height="13.5"/>
                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="11"/>
                                                     <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -1504,21 +1488,21 @@
                                         </connections>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" textLabel="Min-FO-Ubn" detailTextLabel="heQ-HL-pDZ" style="IBUITableViewCellStyleSubtitle" id="i5o-st-7GA" userLabel="WKWebView">
-                                        <rect key="frame" x="0.0" y="308" width="375" height="44"/>
+                                        <rect key="frame" x="0.0" y="336" width="375" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="i5o-st-7GA" id="RCl-RQ-Zpf">
-                                            <rect key="frame" x="0.0" y="0.0" width="342" height="44"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="347.5" height="44"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="WKWebView" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="Min-FO-Ubn">
-                                                    <rect key="frame" x="15" y="6" width="92.5" height="19.5"/>
+                                                    <rect key="frame" x="16" y="6" width="92.5" height="19.5"/>
                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="16"/>
                                                     <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Wait. This could be UIWebView?!?" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="heQ-HL-pDZ">
-                                                    <rect key="frame" x="15" y="25.5" width="178" height="13.5"/>
+                                                    <rect key="frame" x="16" y="25.5" width="178" height="13.5"/>
                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="11"/>
                                                     <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -1532,21 +1516,21 @@
                                         </connections>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" textLabel="AKI-Em-wiO" detailTextLabel="fhX-kH-GnT" style="IBUITableViewCellStyleSubtitle" id="YQ3-v2-BIf" userLabel="WKWebView">
-                                        <rect key="frame" x="0.0" y="352" width="375" height="44"/>
+                                        <rect key="frame" x="0.0" y="380" width="375" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="YQ3-v2-BIf" id="FcV-1L-C5t">
-                                            <rect key="frame" x="0.0" y="0.0" width="342" height="44"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="347.5" height="44"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="SafariWebController" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="AKI-Em-wiO">
-                                                    <rect key="frame" x="15" y="6" width="146" height="19.5"/>
+                                                    <rect key="frame" x="16" y="6" width="146" height="19.5"/>
                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="16"/>
                                                     <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="A matrix of control" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="fhX-kH-GnT">
-                                                    <rect key="frame" x="15" y="25.5" width="97.5" height="13.5"/>
+                                                    <rect key="frame" x="16" y="25.5" width="97.5" height="13.5"/>
                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="11"/>
                                                     <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -1560,10 +1544,10 @@
                                         </connections>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" textLabel="qCc-oA-wDv" detailTextLabel="gbI-dQ-slM" style="IBUITableViewCellStyleSubtitle" id="92o-Pk-gug" userLabel="GemüseMe">
-                                        <rect key="frame" x="0.0" y="396" width="375" height="44"/>
+                                        <rect key="frame" x="0.0" y="424" width="375" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="92o-Pk-gug" id="VEI-VV-evY">
-                                            <rect key="frame" x="0.0" y="0.0" width="341" height="43.5"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="347.5" height="44"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Gemüse Me" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="qCc-oA-wDv">
@@ -1633,21 +1617,21 @@
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <prototypes>
                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="reuseIdentifier" textLabel="Dd6-bL-UJ7" detailTextLabel="z2j-Kr-tHS" style="IBUITableViewCellStyleSubtitle" id="5Gs-r7-fM3">
-                                <rect key="frame" x="0.0" y="28" width="375" height="44"/>
+                                <rect key="frame" x="0.0" y="28" width="375" height="55.5"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="5Gs-r7-fM3" id="Btm-GE-KW0">
-                                    <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="375" height="55.5"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <label opaque="NO" multipleTouchEnabled="YES" tag="3030" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Title" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="Dd6-bL-UJ7">
-                                            <rect key="frame" x="16" y="5" width="33.5" height="20.5"/>
+                                            <rect key="frame" x="16" y="10" width="33.5" height="20.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                             <nil key="textColor"/>
                                             <nil key="highlightedColor"/>
                                         </label>
                                         <label opaque="NO" multipleTouchEnabled="YES" tag="3031" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Subtitle" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="z2j-Kr-tHS">
-                                            <rect key="frame" x="16" y="25.5" width="44" height="14.5"/>
+                                            <rect key="frame" x="16" y="31.5" width="44" height="14.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="12"/>
                                             <nil key="textColor"/>
@@ -1718,7 +1702,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="5RJ-bV-srm" userLabel="Same as">
-                                <rect key="frame" x="16" y="325" width="100" height="44"/>
+                                <rect key="frame" x="16" y="305" width="100" height="44"/>
                                 <color key="backgroundColor" red="0.49803921579999999" green="0.49803921579999999" blue="0.49803921579999999" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <accessibility key="accessibilityConfiguration" identifier="same as" label="Same as">
                                     <bool key="isElement" value="YES"/>
@@ -1729,7 +1713,7 @@
                                 </constraints>
                             </view>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="HUa-yn-lcw">
-                                <rect key="frame" x="16" y="281" width="100" height="44"/>
+                                <rect key="frame" x="16" y="261" width="100" height="44"/>
                                 <color key="backgroundColor" red="0.80000001190000003" green="0.80000001190000003" blue="0.80000001190000003" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <accessibility key="accessibilityConfiguration" identifier="same as" label="Same as"/>
                                 <constraints>
@@ -1739,7 +1723,7 @@
                                 <state key="normal" title="Same as"/>
                             </button>
                             <label opaque="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Same as" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="U1v-pG-MDI">
-                                <rect key="frame" x="16" y="156" width="100" height="44"/>
+                                <rect key="frame" x="16" y="136" width="100" height="44"/>
                                 <color key="backgroundColor" red="0.90196079019999997" green="0.90196079019999997" blue="0.90196079019999997" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <accessibility key="accessibilityConfiguration" identifier="same as" label="Same as"/>
                                 <constraints>
@@ -1751,7 +1735,7 @@
                                 <nil key="highlightedColor"/>
                             </label>
                             <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Same as" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="CUB-Sx-jTW">
-                                <rect key="frame" x="16" y="244" width="100" height="30"/>
+                                <rect key="frame" x="16" y="224" width="100" height="30"/>
                                 <color key="backgroundColor" red="0.90196079019999997" green="0.90196079019999997" blue="0.90196079019999997" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <accessibility key="accessibilityConfiguration" identifier="same as" label="Same as"/>
                                 <constraints>
@@ -1762,7 +1746,7 @@
                                 <textInputTraits key="textInputTraits"/>
                             </textField>
                             <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" text="Same as" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="NPg-ZF-AXx">
-                                <rect key="frame" x="16" y="207" width="100" height="30"/>
+                                <rect key="frame" x="16" y="187" width="100" height="30"/>
                                 <accessibility key="accessibilityConfiguration" identifier="same as" label="Same as"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="30" id="cmv-PL-uSH"/>
@@ -1772,7 +1756,7 @@
                                 <textInputTraits key="textInputTraits"/>
                             </textField>
                             <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="Afo-pr-YJT">
-                                <rect key="frame" x="16" y="112" width="100" height="44"/>
+                                <rect key="frame" x="16" y="92" width="100" height="44"/>
                                 <color key="backgroundColor" red="0.49803921579999999" green="0.49803921579999999" blue="0.49803921579999999" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <accessibility key="accessibilityConfiguration" identifier="same as" label="Same as"/>
                                 <constraints>
@@ -1783,7 +1767,7 @@
                                 <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
                             </textView>
                             <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" text="Same as" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="nTv-4V-gFF">
-                                <rect key="frame" x="16" y="68" width="100" height="44"/>
+                                <rect key="frame" x="16" y="48" width="100" height="44"/>
                                 <color key="backgroundColor" red="0.29803922770000002" green="0.29803922770000002" blue="0.29803922770000002" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <accessibility key="accessibilityConfiguration" identifier="same as" label="Same as"/>
                                 <constraints>
@@ -1795,7 +1779,7 @@
                                 <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
                             </textView>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Here there be newlines" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="3" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="0So-1C-bYg">
-                                <rect key="frame" x="116" y="68" width="80" height="88"/>
+                                <rect key="frame" x="116" y="48" width="80" height="88"/>
                                 <color key="backgroundColor" red="0.80000001190000003" green="0.80000001190000003" blue="0.80000001190000003" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <accessibility key="accessibilityConfiguration" identifier="newlines"/>
                                 <constraints>
@@ -1807,7 +1791,7 @@
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="110%" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="gB7-0a-hKf">
-                                <rect key="frame" x="116" y="156" width="80" height="44"/>
+                                <rect key="frame" x="116" y="136" width="80" height="44"/>
                                 <color key="backgroundColor" red="0.50196081400000003" green="0.50196081400000003" blue="0.50196081400000003" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <accessibility key="accessibilityConfiguration" identifier="percent"/>
                                 <constraints>
@@ -1819,7 +1803,7 @@
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="TAB:char" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="pcw-a4-A7U">
-                                <rect key="frame" x="116" y="200" width="140" height="44"/>
+                                <rect key="frame" x="116" y="180" width="140" height="44"/>
                                 <color key="backgroundColor" red="0.29803922770000002" green="0.29803922770000002" blue="0.29803922770000002" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <accessibility key="accessibilityConfiguration" identifier="control"/>
                                 <constraints>
@@ -1831,7 +1815,7 @@
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="&quot;quoted&quot;" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="0yt-Ka-ycs">
-                                <rect key="frame" x="116" y="244" width="80" height="37"/>
+                                <rect key="frame" x="116" y="224" width="80" height="37"/>
                                 <color key="backgroundColor" red="0.50196081400000003" green="0.50196081400000003" blue="0.50196081400000003" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <accessibility key="accessibilityConfiguration" identifier="quoted"/>
                                 <constraints>
@@ -1843,7 +1827,7 @@
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Karl's Problem" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ZLQ-jR-5dQ">
-                                <rect key="frame" x="116" y="281" width="80" height="44"/>
+                                <rect key="frame" x="116" y="261" width="80" height="44"/>
                                 <color key="backgroundColor" red="0.90196079019999997" green="0.90196079019999997" blue="0.90196079019999997" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <accessibility key="accessibilityConfiguration" identifier="single quote"/>
                                 <constraints>
@@ -1855,7 +1839,7 @@
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="LIKE?" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="4k6-bN-Dly">
-                                <rect key="frame" x="116" y="325" width="80" height="44"/>
+                                <rect key="frame" x="116" y="305" width="80" height="44"/>
                                 <color key="backgroundColor" red="0.7019608021" green="0.7019608021" blue="0.7019608021" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <accessibility key="accessibilityConfiguration" identifier="like"/>
                                 <constraints>
@@ -2006,18 +1990,18 @@
                                 <rect key="frame" x="0.0" y="28" width="375" height="44"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="0dk-wx-Pq2" id="LQp-nd-5di">
-                                    <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <label opaque="NO" multipleTouchEnabled="YES" tag="3030" contentMode="left" text="Title" textAlignment="natural" lineBreakMode="middleTruncation" baselineAdjustment="alignBaselines" minimumFontSize="8" adjustsLetterSpacingToFitWidth="YES" id="T5L-SR-UDt">
-                                            <rect key="frame" x="15" y="5" width="33.5" height="20.5"/>
+                                            <rect key="frame" x="16" y="5" width="33.5" height="20.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                             <nil key="textColor"/>
                                             <nil key="highlightedColor"/>
                                         </label>
                                         <label opaque="NO" multipleTouchEnabled="YES" tag="3031" contentMode="left" text="Subtitle" textAlignment="natural" lineBreakMode="middleTruncation" baselineAdjustment="alignBaselines" minimumFontSize="6" adjustsLetterSpacingToFitWidth="YES" id="Xp4-r0-KMH">
-                                            <rect key="frame" x="15" y="25.5" width="44" height="14.5"/>
+                                            <rect key="frame" x="16" y="25.5" width="44" height="14.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="12"/>
                                             <nil key="textColor"/>
@@ -2053,18 +2037,18 @@
                                 <rect key="frame" x="0.0" y="28" width="375" height="64"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="ZFT-0H-bpe" id="8vy-Jr-FI5">
-                                    <rect key="frame" x="0.0" y="0.0" width="375" height="63.5"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="375" height="64"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <label opaque="NO" multipleTouchEnabled="YES" tag="3030" contentMode="left" text="Title" textAlignment="natural" lineBreakMode="middleTruncation" baselineAdjustment="alignBaselines" minimumFontSize="6" adjustsLetterSpacingToFitWidth="YES" id="yHz-mI-KPt">
-                                            <rect key="frame" x="15" y="15" width="33.5" height="20.5"/>
+                                            <rect key="frame" x="16" y="12" width="33.5" height="20.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                             <nil key="textColor"/>
                                             <nil key="highlightedColor"/>
                                         </label>
                                         <label opaque="NO" multipleTouchEnabled="YES" tag="3031" contentMode="left" text="Detail" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="6" adjustsLetterSpacingToFitWidth="YES" id="Qfe-Vf-8L3">
-                                            <rect key="frame" x="15" y="35.5" width="33" height="14.5"/>
+                                            <rect key="frame" x="16" y="35.5" width="33" height="14.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="12"/>
                                             <nil key="textColor"/>
@@ -2100,11 +2084,11 @@
                                 <rect key="frame" x="0.0" y="28" width="375" height="44"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="IVT-2K-uic" id="75S-4E-djs">
-                                    <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <label opaque="NO" multipleTouchEnabled="YES" tag="3030" contentMode="left" text="Title" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="mjG-GL-VdP">
-                                            <rect key="frame" x="15" y="0.0" width="345" height="43.5"/>
+                                            <rect key="frame" x="16" y="0.0" width="343" height="44"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                             <nil key="textColor"/>

--- a/TestApp/App/TouchViewController.m
+++ b/TestApp/App/TouchViewController.m
@@ -24,6 +24,10 @@
 @property (weak, nonatomic) IBOutlet UIButton *zeroButton;
 - (IBAction)zeroButtonTouched:(id)sender;
 
+@property (weak, nonatomic) IBOutlet NSLayoutConstraint *zeroButtonHeightConstraint;
+
+@property (weak, nonatomic) IBOutlet NSLayoutConstraint *zeroButtonWidthConstraint;
+
 @property (weak, nonatomic) IBOutlet UIButton *animatedButton;
 - (IBAction)animatedButtonTouched:(id)sender;
 
@@ -144,16 +148,17 @@
 }
 
 - (IBAction)zeroButtonTouched:(id)sender {
-    __weak UIButton *button = self.zeroButton;
-
-    CGSize originalSize = button.size;
-    button.size = CGSizeZero;
+    CGSize originalSize = CGSizeMake(self.zeroButtonWidthConstraint.constant, self.zeroButtonHeightConstraint.constant);
+    self.zeroButtonWidthConstraint.constant = 0;
+    self.zeroButtonHeightConstraint.constant = 0;
 
     // If we use an animation, the button remains hittable!
     dispatch_time_t when = dispatch_time(DISPATCH_TIME_NOW,
                                          4.0 * NSEC_PER_SEC);
     dispatch_after(when, dispatch_get_main_queue(), ^{
-        button.size = originalSize;
+        self.zeroButtonWidthConstraint.constant = originalSize.width;
+        self.zeroButtonHeightConstraint.constant = originalSize.height;
+        
     });
 }
 

--- a/cucumber/features/pan.feature
+++ b/cucumber/features/pan.feature
@@ -43,6 +43,5 @@ And I can swipe to delete the Windows row
 
 Scenario: Reorder table view row
 And I am looking at the Everything's On the Table page
-And I have scrolled to the top of the Companies table
 When I touch the Edit button, the table is in Edit mode
 Then I move the Android row above the Apple row

--- a/cucumber/features/steps/pan.rb
+++ b/cucumber/features/steps/pan.rb
@@ -291,6 +291,9 @@ And(/^I can swipe to delete the Windows row$/) do
 end
 
 And(/^I have scrolled to the top of the Companies table$/) do
+  # Skip this step since StatusBar was deprecated on iOS 13+
+  next if ios_gte?("13.0")
+
   element = wait_for_view({type: "StatusBar", :all => true})
 
   # touching the center of the status bar on iPhone 10 devices is

--- a/cucumber/features/steps/pan.rb
+++ b/cucumber/features/steps/pan.rb
@@ -290,25 +290,6 @@ And(/^I can swipe to delete the Windows row$/) do
   wait_for_no_view({marked: identifier})
 end
 
-And(/^I have scrolled to the top of the Companies table$/) do
-  # Skip this step since StatusBar was deprecated on iOS 13+
-  next if ios_gte?("13.0")
-
-  element = wait_for_view({type: "StatusBar", :all => true})
-
-  # touching the center of the status bar on iPhone 10 devices is
-  # not possible because of the notch.  Let's just touch the top
-  # left of the status bar.
-  hitpoint = element["hit_point"]
-  if hitpoint["x"] != -1
-    touch_coordinate({x: hitpoint["x"], y: hitpoint["y"]})
-  else
-    touch_coordinate({x: 4, y: 4})
-  end
-
-  sleep(0.4)
-end
-
 When(/^I touch the Edit button, the table is in Edit mode$/) do
   touch({marked: "Edit"})
   wait_for_view({marked: "Done"})

--- a/cucumber/features/steps/visibility.rb
+++ b/cucumber/features/steps/visibility.rb
@@ -34,10 +34,10 @@ Then(/^the tab bar is visible and hitable$/) do
 end
 
 Then(/^the status bar is visible and sometimes hitable$/) do
-  # Skip this step since StatusBar was deprecated on iOS 13+
-  next if ios_gte?("13.0")
-
-  if iphone_x? && !device_info["simulator"]
+  if ios_gte?("13.0")
+    log_inline("StatusBar was deprecated on iOS 13+")
+    wait_for_no_view({type: "StatusBar", all: true})
+  elsif iphone_x? && !device_info["simulator"]
     # The StatusBar may or may not be visible on iPhone 10.
     # This is _not_ a timing issue; waiting does not change the outcome.
     element = query({type: "StatusBar", all: true}).first

--- a/cucumber/features/steps/visibility.rb
+++ b/cucumber/features/steps/visibility.rb
@@ -34,6 +34,9 @@ Then(/^the tab bar is visible and hitable$/) do
 end
 
 Then(/^the status bar is visible and sometimes hitable$/) do
+  # The StatusBar was deprecated on iOS 13+
+  next if ios_gte?("13.0")
+
   if iphone_x? && !device_info["simulator"]
     # The StatusBar may or may not be visible on iPhone 10.
     # This is _not_ a timing issue; waiting does not change the outcome.

--- a/cucumber/features/steps/visibility.rb
+++ b/cucumber/features/steps/visibility.rb
@@ -34,7 +34,7 @@ Then(/^the tab bar is visible and hitable$/) do
 end
 
 Then(/^the status bar is visible and sometimes hitable$/) do
-  # The StatusBar was deprecated on iOS 13+
+  # Skip this step since StatusBar was deprecated on iOS 13+
   next if ios_gte?("13.0")
 
   if iphone_x? && !device_info["simulator"]


### PR DESCRIPTION
StatusBar element was deprecated in iOS 13+.
1) Skip `StatusBar` in scenario `What is hitable?` for iOS 13+
2) Skip `StatusBar` click in scenario `Reorder table view row` for iOS 13+
3) Fix test app for iOS 13.
`Zero button` size is defined by constraints. Before we just change its size by `size` property. However, it stops to work in iOS 13+. I have changed approach to use widthConstraint and heightConstraint. It works for both Xcode 11 and Xcode 10.2.1
