### PR TITLE
Publish DeviceAgent.iOS artifacts to blob storage

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,3 +1,7 @@
+variables:
+  # `mainJob` variable points to the matrix case that will be the main case
+  # it will publish artifacts to the Azure Blob
+  mainJob: 'Mojave-Xcode-10.2.1'
 jobs:
 
 - job:
@@ -65,7 +69,7 @@ jobs:
       AZURE_STORAGE_CONNECTION_STRING: $(azureStorageConnectionString)
       SOURCE_BRANCH: $(Build.SourceBranch)
     displayName: "Publish to Azure Blob Storage"
-    condition: and(succeeded(), eq(variables['XCODE_VERSION'], '10.2.1'), startsWith(variables['Build.SourceBranch'], 'refs/tags/*'))
+    condition: and(succeeded(), eq(variables['Agent.JobName'], variables['mainJob']), startsWith(variables['Build.SourceBranch'], 'refs/tags/*'))
 
   - task: PublishTestResults@2
     displayName: 'Publish Test Results'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -65,7 +65,7 @@ jobs:
       AZURE_STORAGE_CONNECTION_STRING: $(azureStorageConnectionString)
       SOURCE_BRANCH: $(Build.SourceBranch)
     displayName: "Publish to Azure Blob Storage"
-    condition: and(succeeded(), eq(variables['XCODE_VERSION'], '10.2.1'))
+    condition: and(succeeded(), eq(variables['XCODE_VERSION'], '10.2.1'), startsWith(variables['Build.SourceBranch'], 'refs/tags/*'))
 
   - task: PublishTestResults@2
     displayName: 'Publish Test Results'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -57,6 +57,16 @@ jobs:
     # This tests will be enabled for the stable Xcode 11 release
     condition: and(succeeded(), ne(variables['XCODE_VERSION'], '11'))
 
+  # azureStorage* env vars are defined in the pipeline UI as secret variables
+  - bash: "./bin/ci/az-publish.sh"
+    env:
+      AZURE_STORAGE_ACCOUNT: $(azureStorageAccount)
+      AZURE_STORAGE_KEY: $(azureStorageKey)
+      AZURE_STORAGE_CONNECTION_STRING: $(azureStorageConnectionString)
+      SOURCE_BRANCH: $(Build.SourceBranch)
+    displayName: "Publish to Azure Blob Storage"
+    condition: and(succeeded(), eq(variables['XCODE_VERSION'], '10.2.1'))
+
   - task: PublishTestResults@2
     displayName: 'Publish Test Results'
     inputs:

--- a/bin/ci/az-publish.sh
+++ b/bin/ci/az-publish.sh
@@ -7,11 +7,10 @@ set -eo pipefail
 # $1 => SOURCE PATH
 # $2 => TARGET NAME
 function azupload {
-  echo "Dry run: ${1} published with name: ${2}"
-# az storage blob upload \
-#   --container-name ios-device-agent \
-#   --file "${1}" \
-#   --name "${2}"
+  az storage blob upload \
+    --container-name ios-device-agent \
+    --file "${1}" \
+    --name "${2}"
   echo "${1} artifact uploaded with name ${2}"
 }
 

--- a/bin/ci/az-publish.sh
+++ b/bin/ci/az-publish.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+
+source bin/xcode.sh
+
+set -eo pipefail
+
+# $1 => SOURCE PATH
+# $2 => TARGET NAME
+function azupload {
+  echo "Dry run: ${1} published with name: ${2}"
+# az storage blob upload \
+#   --container-name ios-device-agent \
+#   --file "${1}" \
+#   --name "${2}"
+  echo "${1} artifact uploaded with name ${2}"
+}
+
+# Pipeline Variables are set through the AzDevOps UI
+# See also the ./azdevops-pipeline.yml
+if [[ -z "${AZURE_STORAGE_ACCOUNT}" ]]; then
+  echo "AZURE_STORAGE_ACCOUNT is required"
+  exit 1
+fi
+
+if [[ -z "${AZURE_STORAGE_KEY}" ]]; then
+  echo "AZURE_STORAGE_KEY is required"
+  exit 1
+fi
+
+if [[ -z "${AZURE_STORAGE_CONNECTION_STRING}" ]]; then
+  echo "AZURE_STORAGE_CONNECTION_STRING is required"
+  exit 1
+fi
+
+# Evaluate git-sha value
+GIT_SHA=$(git rev-parse --verify HEAD | tr -d '\n')
+
+# Evaluate DeviceAgent version (from Info.plist)
+VERSION=$(plutil -p ./Products/app/DeviceAgent/DeviceAgent-Runner.app/Info.plist | grep CFBundleShortVersionString | grep -o '"[[:digit:].]*"' | sed 's/"//g')
+
+# Evaluate the Xcode version used to build artifacts
+XC_VERSION=$(xcode_version)
+
+az --version
+
+WORKING_DIR="${BUILD_SOURCESDIRECTORY}"
+
+# Upload `DeviceAgent.ipa`
+IPA="${WORKING_DIR}/Products/ipa/DeviceAgent/DeviceAgent-Runner.ipa"
+IPA_NAME="DeviceAgent-${VERSION}-Xcode-${XC_VERSION}-${GIT_SHA}.ipa"
+azupload "${IPA}" "${IPA_NAME}"
+
+# Upload `DeviceAgent.app`
+APP="${WORKING_DIR}/Products/app/DeviceAgent/DeviceAgent-Runner.app"
+APP_NAME="DeviceAgent-${VERSION}-Xcode-${XC_VERSION}-${GIT_SHA}.app"
+azupload "${APP}" "${APP_NAME}"


### PR DESCRIPTION
This PR adds new build step to the azure-pipelines.yml file. This build step will perform publishing of build artifacts (see exact list of artifacts below) to the Azure Blob storage (Container name: `ios-device-agent`). Artifacts from build job with macOS Mojave and Xcode 10.2.1 would be published.

List of artifacts:
```
DeviceAgent.ipa
DeviceAgent.app
```