### PR TITLE
Update private headers for Xcode 11 GM

### DIFF
--- a/Server/PrivateHeaders/XCTAutomationSupport/XCTElementBlockFilteringTransformer.h
+++ b/Server/PrivateHeaders/XCTAutomationSupport/XCTElementBlockFilteringTransformer.h
@@ -30,6 +30,7 @@
 @property(readonly) BOOL supportsAttributeKeyPathAnalysis;
 @property(readonly) BOOL supportsRemoteEvaluation;
 
++ (void)provideCapabilitiesToBuilder:(id)arg1;
 - (BOOL)canBeRemotelyEvaluatedWithCapabilities:(id)arg1;
 - (id)initWithBlockFilter:(CDUnknownBlockType)arg1;
 - (id)iteratorForInput:(id)arg1;

--- a/Server/PrivateHeaders/XCTAutomationSupport/XCTElementBlockSortingTransformer.h
+++ b/Server/PrivateHeaders/XCTAutomationSupport/XCTElementBlockSortingTransformer.h
@@ -30,6 +30,7 @@
 @property(readonly) BOOL supportsAttributeKeyPathAnalysis;
 @property(readonly) BOOL supportsRemoteEvaluation;
 
++ (void)provideCapabilitiesToBuilder:(id)arg1;
 - (BOOL)canBeRemotelyEvaluatedWithCapabilities:(id)arg1;
 - (id)initWithComparator:(CDUnknownBlockType)arg1;
 - (id)iteratorForInput:(id)arg1;

--- a/Server/PrivateHeaders/XCTAutomationSupport/XCTElementContainingTransformer.h
+++ b/Server/PrivateHeaders/XCTAutomationSupport/XCTElementContainingTransformer.h
@@ -23,6 +23,7 @@
 
 @property(readonly, copy) NSPredicate *predicate;
 
++ (void)provideCapabilitiesToBuilder:(id)arg1;
 - (BOOL)_elementMatches:(id)arg1 relatedElement:(id *)arg2;
 - (BOOL)canBeRemotelyEvaluatedWithCapabilities:(id)arg1;
 - (id)initWithPredicate:(id)arg1;

--- a/Server/PrivateHeaders/XCTAutomationSupport/XCTElementIndexingTransformer.h
+++ b/Server/PrivateHeaders/XCTAutomationSupport/XCTElementIndexingTransformer.h
@@ -25,6 +25,7 @@
 @property(retain) XCTIndexingTransformerIterator *currentIterator;
 @property(readonly) NSUInteger elementIndex;
 
++ (void)provideCapabilitiesToBuilder:(id)arg1;
 - (BOOL)canBeRemotelyEvaluatedWithCapabilities:(id)arg1;
 - (id)initWithElementIndex:(NSUInteger)arg1;
 - (id)iteratorForInput:(id)arg1;

--- a/Server/PrivateHeaders/XCTAutomationSupport/XCTElementSetCodableTransformer.h
+++ b/Server/PrivateHeaders/XCTAutomationSupport/XCTElementSetCodableTransformer.h
@@ -28,6 +28,7 @@
 @property(readonly) BOOL supportsAttributeKeyPathAnalysis;
 @property(readonly) BOOL supportsRemoteEvaluation;
 
++ (void)provideCapabilitiesToBuilder:(id)arg1;
 - (BOOL)canBeRemotelyEvaluatedWithCapabilities:(id)arg1;
 - (id)iteratorForInput:(id)arg1;
 - (id)requiredKeyPathsOrError:(id *)arg1;

--- a/Server/PrivateHeaders/XCTAutomationSupport/XCTElementSetTransformer-Protocol.h
+++ b/Server/PrivateHeaders/XCTAutomationSupport/XCTElementSetTransformer-Protocol.h
@@ -5,7 +5,6 @@
 //  Copyright (C) 1997-2019 Steve Nygard.
 //
 
-
 #import <Foundation/Foundation.h>
 #import <CoreGraphics/CoreGraphics.h>
 #import <XCTest/XCUIElementTypes.h>
@@ -13,10 +12,12 @@
 @protocol OS_dispatch_queue;
 @protocol OS_xpc_object;
 
+#import "XCTCapabilitiesProviding-Protocol.h"
+
 @class NSOrderedSet, NSSet, NSString, XCElementSnapshot, XCTCapabilities;
 @protocol XCTMatchingElementIterator;
 
-@protocol XCTElementSetTransformer <NSObject, NSCopying>
+@protocol XCTElementSetTransformer <NSObject, NSCopying, XCTCapabilitiesProviding>
 - (BOOL)canBeRemotelyEvaluatedWithCapabilities:(XCTCapabilities *)arg1;
 - (id <XCTMatchingElementIterator>)iteratorForInput:(XCElementSnapshot *)arg1;
 - (NSSet *)requiredKeyPathsOrError:(id *)arg1;

--- a/Server/PrivateHeaders/XCTest/XCUIElement.h
+++ b/Server/PrivateHeaders/XCTest/XCUIElement.h
@@ -52,6 +52,7 @@
 @property(readonly, copy) XCUIElementQuery *drawers;
 @property(readonly, copy) XCUIElement *elementBoundByAccessibilityElement;
 @property(readonly) NSUInteger elementType;
+@property(readonly, copy) XCUIElement *excludingNonModalElements;
 @property(readonly) BOOL exists;
 @property(readonly) XCUIElement *firstMatch;
 @property(readonly) CGRect frame;

--- a/Server/PrivateHeaders/XCTest/XCUIElementQuery.h
+++ b/Server/PrivateHeaders/XCTest/XCUIElementQuery.h
@@ -63,6 +63,7 @@
 @property(readonly) XCUIElement *element;
 @property(readonly, copy) NSString *elementDescription;
 @property(readonly) id <XCTElementSnapshotAttributeDataSource> elementSnapshotAttributeDataSource;
+@property(readonly, copy) XCUIElementQuery *excludingNonModalElements;
 @property(copy) NSArray *expressedIdentifiers;
 @property(copy) NSSet *expressedTypes;
 @property(readonly) XCUIElement *firstMatch;


### PR DESCRIPTION
Private headers were updated according to Xcode 11 GM by running this script: `bin/class-dump/dump.rb`