### PR TITLE
Add support for new devices

### DIFF
--- a/Server/Utilities/CBXDevice.m
+++ b/Server/Utilities/CBXDevice.m
@@ -258,6 +258,11 @@ NSString *const CBXDeviceSimKeyVersionInfo = @"SIMULATOR_VERSION_INFO";
       @"iPhone11,6" : @"iphone 10s max",
       @"iPhone11,8" : @"iphone 10r",
 
+      // iPhone 11/11 Pro/11 Pro Max
+      @"iPhone12,1" : @"iphone 11",
+      @"iPhone12,3" : @"iphone 11 Pro",
+      @"iPhone12,5" : @"iphone 11 Pro Max",
+
       // iPad Pro 13in
       @"iPad6,7" : @"ipad pro",
       @"iPad6,8" : @"ipad pro",
@@ -286,7 +291,15 @@ NSString *const CBXDeviceSimKeyVersionInfo = @"SIMULATOR_VERSION_INFO";
       @"iPad8,5" : @"ipad pro",
       @"iPad8,6" : @"ipad pro",
       @"iPad8,7" : @"ipad pro",
-      @"iPad8,8" : @"ipad pro"
+      @"iPad8,8" : @"ipad pro",
+
+      // iPad mini 7,9in
+      @"iPad11,1" : @"ipad mini",
+      @"iPad11,2" : @"ipad mini",
+
+      // iPad Air 10.5in
+      @"iPad11,3" : @"ipad air",
+      @"iPad11,4" : @"ipad air",
       };
 
     return _formFactorMap;


### PR DESCRIPTION
Add support for new iPhones (11, 11 Pro and 11 Pro Max), iPad mini 5th Gen and iPad Air 2019