### PR TITLE
Use equal names for devices with the same screen size

### DIFF
--- a/Server/Utilities/CBXDevice.m
+++ b/Server/Utilities/CBXDevice.m
@@ -259,9 +259,9 @@ NSString *const CBXDeviceSimKeyVersionInfo = @"SIMULATOR_VERSION_INFO";
       @"iPhone11,8" : @"iphone 10r",
 
       // iPhone 11/11 Pro/11 Pro Max
-      @"iPhone12,1" : @"iphone 11",
-      @"iPhone12,3" : @"iphone 11 Pro",
-      @"iPhone12,5" : @"iphone 11 Pro Max",
+      @"iPhone12,1" : @"iphone 10r",
+      @"iPhone12,3" : @"iphone 10",
+      @"iPhone12,5" : @"iphone 10s max",
 
       // iPad Pro 13in
       @"iPad6,7" : @"ipad pro",


### PR DESCRIPTION
Mapping for new devices was changed in this PR as follows:
`iPhone 11` -> `iphone 10r`
`iphone 11 Pro` -> `iphone 10`
`iphone 11 Pro Max` -> `iphone 10s max`

We have to change device mapping cause we use the same approach for iPhone 6/7/8 (`iphone 6`) and iPhone 6+/7+/8+ (`iphone 6+`)