### PR TITLE
build/publish: can upload to Azure Blob Storage locally

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ Gemfile.lock
 .appcenter-credentials
 testcloud-submit
 bin/test-cloud-uploader
+.azure-credentials
 
 # JetBrains
 .idea


### PR DESCRIPTION
### Motivation

Progress on:

* [Test] Support iOS 13 [ADO](https://msmobilecenter.visualstudio.com/Mobile-Center/_workitems/edit/65142)

We need to publish an _ad hoc_ version of DeviceAgent that Test Cloud can use to test a fix for iOS 13 support.  The current script was not ready run locally.
