### PR TITLE
POST/session: on error, retry launching AUT

### DIFF
--- a/Server/Application/Application.m
+++ b/Server/Application/Application.m
@@ -10,7 +10,6 @@
 #import "CBXException.h"
 #import "JSONUtils.h"
 #import "CBXDevice.h"
-#import "CBLSApplicationWorkspace.h"
 #import "CBXMachClock.h"
 
 @interface Application ()
@@ -63,16 +62,10 @@ static Application *currentApplication;
             break;
         }
 
-
-        NSString *errorMessage;
-        errorMessage = [NSString stringWithFormat:@"Attempt %@ of %@ - could not "
-                        "launch application with bundle identifier: %@\n%@",
-                        @(attempts), @(maxAttempts), self.app.bundleID,
-                        outerError.localizedDescription];
-
-        DDLogDebug(@"Application did not launch (in the loop): Application is installed?  %@",
-                   @([CBLSApplicationWorkspace applicationIsInstalled:self.app.bundleID]));
-
+        DDLogDebug(@"Attempt %@ of %@ - could not launch application with "
+                   "bundle identifier: %@\n%@",
+                   @(attempts), @(maxAttempts), self.app.bundleID,
+                   outerError.localizedDescription);
 
         CFRunLoopRunInMode(kCFRunLoopDefaultMode, sleepBetween, false);
         attempts = attempts + 1;

--- a/Server/Application/Application.m
+++ b/Server/Application/Application.m
@@ -10,6 +10,8 @@
 #import "CBXException.h"
 #import "JSONUtils.h"
 #import "CBXDevice.h"
+#import "CBLSApplicationWorkspace.h"
+#import "CBXMachClock.h"
 
 @interface Application ()
 @property (nonatomic, strong) XCUIApplication *app;
@@ -32,22 +34,61 @@ static Application *currentApplication;
 - (void)startSession {
     DDLogDebug(@"Launching application '%@'", self.app.bundleID);
 
+    // In some contexts, the application has not been completely installed
+    // when the POST /session route is called. In that case, the launch will
+    // fail with a detectable error.
+    //
+    // The private LSApplicationWorkspace API does not work on physical devices
+    // so we cannot poll to wait for the application to install.
+    NSUInteger attempts = 1;
+    NSUInteger maxAttempts = 12;
+    NSTimeInterval sleepBetween = 5;
+    NSTimeInterval start = [[CBXMachClock sharedClock] absoluteTime];
+
     __block NSError *outerError = nil;
-    [ThreadUtils runSync:^(BOOL *setToTrueWhenDone) {
-        [[Testmanagerd get] _XCT_launchApplicationWithBundleID:self.app.bundleID
-                                                     arguments:self.app.launchArguments
-                                                   environment:self.app.launchEnvironment
-                                                    completion:^(NSError *innerError) {
-                                                        outerError = innerError;
-                                                        *setToTrueWhenDone = YES;
-                                                    }];
-    }];
+
+    do {
+        [ThreadUtils runSync:^(BOOL *setToTrueWhenDone) {
+            [[Testmanagerd get]
+             _XCT_launchApplicationWithBundleID:self.app.bundleID
+             arguments:self.app.launchArguments
+             environment:self.app.launchEnvironment
+             completion:^(NSError *innerError) {
+                outerError = innerError;
+                *setToTrueWhenDone = YES;
+            }];
+        }];
+
+        if (!outerError) {
+            break;
+        }
+
+
+        NSString *errorMessage;
+        errorMessage = [NSString stringWithFormat:@"Attempt %@ of %@ - could not "
+                        "launch application with bundle identifier: %@\n%@",
+                        @(attempts), @(maxAttempts), self.app.bundleID,
+                        outerError.localizedDescription];
+
+        DDLogDebug(@"Application did not launch (in the loop): Application is installed?  %@",
+                   @([CBLSApplicationWorkspace applicationIsInstalled:self.app.bundleID]));
+
+
+        CFRunLoopRunInMode(kCFRunLoopDefaultMode, sleepBetween, false);
+        attempts = attempts + 1;
+    } while (attempts < maxAttempts + 1);
+
+    NSTimeInterval elapsed = [[CBXMachClock sharedClock] absoluteTime] - start;
 
     if (outerError) {
         NSString *errorMessage;
-        errorMessage = [NSString stringWithFormat:@"Could not launch application with bundle identifier: %@\n%@",
-                        self.app.bundleID, outerError.localizedDescription];
+        errorMessage = [NSString stringWithFormat:@"Failed to launch application "
+                        "with bundle identifier: %@ after %@ tries over %@ seconds.\n"
+                        "Is the app installed?",
+                        self.app.bundleID, @(attempts), @(elapsed)];
         @throw [CBXException withMessage:errorMessage userInfo:nil];
+    } else {
+        DDLogDebug(@"Launched %@ after %@ seconds", self.app.bundleID, @(elapsed));
     }
 }
 

--- a/bin/ci/az-publish.sh
+++ b/bin/ci/az-publish.sh
@@ -63,7 +63,7 @@ fi
 IPA="${PRODUCT_DIR}/DeviceAgent-Runner.ipa"
 azupload "${IPA}" "${BUILD_ID}.ipa"
 
-APP="${WORKING_DIR}/Products/app/DeviceAgent-Runner.app.zip"
+APP="${WORKING_DIR}/Products/app/DeviceAgent/DeviceAgent-Runner.app.zip"
 azupload "${APP}" "${BUILD_ID}.app.zip"
 
 echo "${BUILD_ID}"


### PR DESCRIPTION
### Motivation

In some contexts, the application has not been completely installed when the POST /session route is called. In that case, the launch will fail with a detectable error.

Progress on:

* [Test] Support iOS 13 [ADO](https://msmobilecenter.visualstudio.com/Mobile-Center/_workitems/edit/65142)
