### PR TITLE
Update private headers for Xcode 11.2 beta 2

### DIFF
--- a/Server/PrivateHeaders/XCTAutomationSupport/XCAccessibilityElement.h
+++ b/Server/PrivateHeaders/XCTAutomationSupport/XCAccessibilityElement.h
@@ -39,11 +39,12 @@
 + (id)deviceElement;
 + (id)elementWithAXUIElement:(struct __AXUIElement *)arg1;
 + (id)elementWithProcessIdentifier:(NSInteger)arg1;
++ (id)elementWithProcessIdentifier:(NSInteger)arg1 originPlatform:(NSUInteger)arg2;
 + (id)mockElementWithProcessIdentifier:(NSInteger)arg1;
 + (id)mockElementWithProcessIdentifier:(NSInteger)arg1 originPlatform:(NSUInteger)arg2;
 + (id)mockElementWithProcessIdentifier:(NSInteger)arg1 originPlatform:(NSUInteger)arg2 payload:(id)arg3;
 + (id)mockElementWithProcessIdentifier:(NSInteger)arg1 payload:(id)arg2;
-- (id)initWithAXUIElement:(struct __AXUIElement *)arg1 elementType:(NSUInteger)arg2;
+- (id)initWithAXUIElement:(struct __AXUIElement *)arg1 elementType:(NSUInteger)arg2 originPlatform:(NSUInteger)arg3;
 - (id)initWithToken:(id)arg1 elementOrHash:(NSUInteger)arg2 elementID:(NSUInteger)arg3 pid:(NSInteger)arg4 elementType:(NSUInteger)arg5 originPlatform:(NSUInteger)arg6;
 
 @end

--- a/Server/PrivateHeaders/XCTAutomationSupport/XCElementSnapshot.h
+++ b/Server/PrivateHeaders/XCTAutomationSupport/XCElementSnapshot.h
@@ -111,6 +111,7 @@
 @property(readonly) CGRect visibleFrame;
 
 + (id)axAttributesForElementSnapshotKeyPaths:(id)arg1 isMacOS:(BOOL)arg2;
++ (id)axAttributesForFaultingPropertiesOnMacOS:(BOOL)arg1;
 + (id)axAttributesForSnapshotAttributes:(id)arg1 isMacOS:(BOOL)arg2;
 + (NSUInteger)elementTypeForAccessibilityElement:(id)arg1 usingAXAttributes_iOS:(id)arg2 useLegacyElementType:(BOOL)arg3;
 + (NSUInteger)elementTypeForAccessibilityElement:(id)arg1 usingAXAttributes_macOS:(id)arg2 useLegacyElementType:(BOOL)arg3;

--- a/Server/PrivateHeaders/XCTAutomationSupport/XCTAutomationSession.h
+++ b/Server/PrivateHeaders/XCTAutomationSupport/XCTAutomationSession.h
@@ -16,13 +16,19 @@
 
 #import "XCTAutomationTarget-Protocol.h"
 #import "XCTConnectionAccepting-Protocol.h"
+#import "XCTElementSnapshotAttributeDataSource-Protocol.h"
+#import "XCTElementSnapshotProvider-Protocol.h"
 #import "XCTRemoteApplicationAutomationTarget-Protocol.h"
 
 @class DTXConnection, DTXProxyChannel, NSMutableArray, NSString, XCTAnimationsIdleNotifier, XCTCapabilities, XCTElementQueryProcessor, XCTMainRunLoopIdleNotifier;
-@protocol OS_dispatch_queue;
+@protocol OS_dispatch_queue, XCTElementSnapshotProvider><XCTElementSnapshotAttributeDataSource;
 
-@interface XCTAutomationSession : NSObject <XCTRemoteApplicationAutomationTarget, XCTConnectionAccepting, XCTAutomationTarget>
+
+@protocol XCTElementSnapshotProvider;
+
+@interface XCTAutomationSession : NSObject <XCTRemoteApplicationAutomationTarget, XCTElementSnapshotProvider, XCTElementSnapshotAttributeDataSource, XCTConnectionAccepting, XCTAutomationTarget>
 {
+    id <XCTElementSnapshotProvider><XCTElementSnapshotAttributeDataSource> _dataSource;
     NSMutableArray *_connections;
     XCTElementQueryProcessor *_queryProcessor;
     NSObject<OS_dispatch_queue> *_queue;
@@ -33,14 +39,18 @@
     XCTCapabilities *_remoteInterfaceCapabilities;
 }
 
+@property(readonly) BOOL allowsRemoteAccess;
 @property(readonly) XCTAnimationsIdleNotifier *animationIdleNotifier;
 @property(readonly) NSMutableArray *connections;
+@property(readonly) __weak id <XCTElementSnapshotProvider><XCTElementSnapshotAttributeDataSource> dataSource;
 @property(readonly) DTXConnection *dtxConnection;
 @property(readonly) DTXProxyChannel *proxyChannel;
 @property(readonly) XCTElementQueryProcessor *queryProcessor;
 @property(readonly) NSObject<OS_dispatch_queue> *queue;
 @property(retain) XCTCapabilities *remoteInterfaceCapabilities;
 @property(readonly) XCTMainRunLoopIdleNotifier *runLoopIdleMonitor;
+@property(readonly) BOOL supportsHostedViewCoordinateTransformations;
+@property(readonly) BOOL usePointTransformationsForFrameConversions;
 
 + (id)capabilitiesBuilder;
 - (id)_XCT_attributesForElement:(id)arg1 attributes:(id)arg2;
@@ -49,13 +59,17 @@
 - (id)_XCT_notifyWhenAnimationsAreIdle;
 - (id)_XCT_notifyWhenMainRunLoopIsIdle;
 - (BOOL)acceptNewConnection:(id)arg1;
+- (id)attributesForElement:(id)arg1 attributes:(id)arg2 error:(id *)arg3;
 - (void)attributesForElement:(id)arg1 attributes:(id)arg2 reply:(CDUnknownBlockType)arg3;
 - (void)exchangeCapabilities:(id)arg1 reply:(CDUnknownBlockType)arg2;
 - (void)fetchMatchesForQuery:(id)arg1 reply:(CDUnknownBlockType)arg2;
+- (id)initWithDataSource:(id)arg1;
 - (void)listenForRemoteConnectionViaSerializedTransportWrapper:(id)arg1 completion:(CDUnknownBlockType)arg2;
 - (void)notifyWhenAnimationsAreIdle:(CDUnknownBlockType)arg1;
 - (void)notifyWhenMainRunLoopIsIdle:(CDUnknownBlockType)arg1;
+- (id)parameterizedAttribute:(id)arg1 forElement:(id)arg2 parameter:(id)arg3 error:(id *)arg4;
 - (void)requestHostAppExecutableNameWithReply:(CDUnknownBlockType)arg1;
+- (id)snapshotForElement:(id)arg1 attributes:(id)arg2 parameters:(id)arg3 timeoutControls:(id)arg4 error:(id *)arg5;
 
 
 @end

--- a/Server/PrivateHeaders/XCTAutomationSupport/XCTElementQuery.h
+++ b/Server/PrivateHeaders/XCTAutomationSupport/XCTElementQuery.h
@@ -67,6 +67,7 @@
 - (id)initWithRootElement:(id)arg1 transformers:(id)arg2 options:(NSUInteger)arg3;
 - (id)initWithRootElement:(id)arg1 transformers:(id)arg2 options:(NSUInteger)arg3 isMacOS:(BOOL)arg4;
 - (id)initWithRootElement:(id)arg1 transformers:(id)arg2 options:(NSUInteger)arg3 isMacOS:(BOOL)arg4 timeoutControls:(id)arg5;
+- (id)matchingSnapshotsInSnapshotTree:(id)arg1 relatedElements:(id *)arg2 noMatchesMessage:(id *)arg3 error:(id *)arg4;
 - (id)matchingSnapshotsWithRelatedElements:(id *)arg1 noMatchesMessage:(id *)arg2 error:(id *)arg3;
 
 

--- a/Server/PrivateHeaders/XCTAutomationSupport/XCTElementQueryProcessor.h
+++ b/Server/PrivateHeaders/XCTAutomationSupport/XCTElementQueryProcessor.h
@@ -14,32 +14,23 @@
 
 #import <objc/NSObject.h>
 
-#import "XCTElementSnapshotAttributeDataSource-Protocol.h"
-#import "XCTElementSnapshotProvider-Protocol.h"
-
-@class NSString, XCTCapabilities;
-@protocol XCTElementSnapshotProvider;
+@class XCTCapabilities;
+@protocol XCTElementSnapshotProvider><XCTElementSnapshotAttributeDataSource;
 
 
 @protocol XCTElementSnapshotProvider;
 
-@interface XCTElementQueryProcessor : NSObject <XCTElementSnapshotProvider, XCTElementSnapshotAttributeDataSource>
+@interface XCTElementQueryProcessor : NSObject
 {
-    id <XCTElementSnapshotProvider> _snapshotProvider;
+    id <XCTElementSnapshotProvider><XCTElementSnapshotAttributeDataSource> _dataSource;
     XCTCapabilities *_remoteInterfaceCapabilities;
 }
 
-@property(readonly) BOOL allowsRemoteAccess;
+@property(readonly) __weak id <XCTElementSnapshotProvider><XCTElementSnapshotAttributeDataSource> dataSource;
 @property(retain) XCTCapabilities *remoteInterfaceCapabilities;
-@property __weak id <XCTElementSnapshotProvider> snapshotProvider;
-@property(readonly) BOOL supportsHostedViewCoordinateTransformations;
-@property(readonly) BOOL usePointTransformationsForFrameConversions;
 
-- (id)attributesForElement:(id)arg1 attributes:(id)arg2 error:(id *)arg3;
 - (void)fetchMatchesForQuery:(id)arg1 clientCapabilities:(id)arg2 reply:(CDUnknownBlockType)arg3;
-- (id)parameterizedAttribute:(id)arg1 forElement:(id)arg2 parameter:(id)arg3 error:(id *)arg4;
-- (id)snapshotForElement:(id)arg1 attributes:(id)arg2 parameters:(id)arg3 timeoutControls:(id)arg4 error:(id *)arg5;
-
+- (id)initWithDataSource:(id)arg1;
 
 @end
 

--- a/Server/PrivateHeaders/XCTAutomationSupport/XCTElementSnapshotRequest.h
+++ b/Server/PrivateHeaders/XCTAutomationSupport/XCTElementSnapshotRequest.h
@@ -19,6 +19,7 @@
 
 @interface XCTElementSnapshotRequest : NSObject
 {
+    BOOL _preserveRemoteElementPlaceholders;
     BOOL _loadResult;
     BOOL _hasLoaded;
     XCAccessibilityElement *_element;
@@ -42,6 +43,7 @@
 @property(retain) NSError *loadError;
 @property BOOL loadResult;
 @property(copy) NSDictionary *parameters;
+@property BOOL preserveRemoteElementPlaceholders;
 @property(readonly) NSObject<OS_dispatch_queue> *queue;
 @property(readonly) XCTTimeoutControls *timeoutControls;
 

--- a/Server/PrivateHeaders/XCTest/XCTestManager_ManagerInterface-Protocol.h
+++ b/Server/PrivateHeaders/XCTest/XCTestManager_ManagerInterface-Protocol.h
@@ -9,6 +9,7 @@
 #import <CoreGraphics/CoreGraphics.h>
 #import <XCTest/XCUIElementTypes.h>
 #import "CDStructures.h"
+#import "../XCTAutomationSupport/XCUIElementSnapshotRequestResult.h"
 @protocol OS_dispatch_queue;
 @protocol OS_xpc_object;
 

--- a/Server/PrivateHeaders/XCTest/XCTestManager_ManagerInterface-Protocol.h
+++ b/Server/PrivateHeaders/XCTest/XCTestManager_ManagerInterface-Protocol.h
@@ -9,7 +9,6 @@
 #import <CoreGraphics/CoreGraphics.h>
 #import <XCTest/XCUIElementTypes.h>
 #import "CDStructures.h"
-#import "../XCTAutomationSupport/XCUIElementSnapshotRequestResult.h"
 @protocol OS_dispatch_queue;
 @protocol OS_xpc_object;
 


### PR DESCRIPTION
Private headers were updated according to Xcode 11.2 beta 2 by executing `bin/class-dump/dump.rb`