### PR TITLE
Move element resolving logic for different Xcode versions to `cbx_resolve` method

### DIFF
--- a/Server/Application/SpringBoard.m
+++ b/Server/Application/SpringBoard.m
@@ -170,11 +170,7 @@ typedef enum : NSUInteger {
         button = alert.buttons[mark];
 
         // Resolve before asking if the button exists.
-        if ([button respondsToSelector:@selector(resolve)]) {
-            [button resolve];
-        } else {
-            [button resolveOrRaiseTestFailure];
-        }
+        [button cbx_resolve];
 
         if (button && button.exists) {
             return button;
@@ -270,15 +266,7 @@ typedef enum : NSUInteger {
     }
 
     // Resolve before asking if the button exists.
-    if ([button respondsToSelector:@selector(resolve)]) {
-        [button resolve];
-    } else {
-        NSError *error = nil;
-        if (![button resolveOrRaiseTestFailure:NO error:&error]) {
-            DDLogWarn(@"Encountered an error resolving element '%@':\n%@",
-                      button, [error localizedDescription]);
-        }
-    }
+    [button cbx_resolve];
 
     if (!button || !button.exists) {
         return SpringBoardAlertHandlerNoAlert;
@@ -301,15 +289,7 @@ typedef enum : NSUInteger {
             return SpringBoardDismissAlertNoAlert;
         } else {
             XCUIElement *button = alert.buttons[title];
-            if ([button respondsToSelector:@selector(resolve)]) {
-                [button resolve];
-            } else {
-                NSError *error = nil;
-                if (![button resolveOrRaiseTestFailure:NO error:&error]) {
-                    DDLogWarn(@"Encountered an error resolving element '%@':\n%@",
-                            button, [error localizedDescription]);
-                }
-            }
+            [button cbx_resolve];
 
             if (!button || !button.exists) {
                 return SpringBoardDismissAlertNoMatchingButton;
@@ -331,15 +311,7 @@ typedef enum : NSUInteger {
 
 - (BOOL)tapAlertButton:(XCUIElement *)alertButton {
     @synchronized (self) {
-        if ([alertButton respondsToSelector:@selector(resolve)]) {
-            [alertButton resolve];
-        } else {
-            NSError *error = nil;
-            if (![alertButton resolveOrRaiseTestFailure:NO error:&error]) {
-                DDLogWarn(@"Encountered an error resolving element '%@':\n%@",
-                        alertButton, [error localizedDescription]);
-            }
-        }
+        [alertButton cbx_resolve];
         CGPoint hitPoint = [self hitPointForAlertButton:alertButton];
 
         if (hitPoint.x < 0 || hitPoint.y < 0) {
@@ -406,15 +378,7 @@ typedef enum : NSUInteger {
 }
 
 - (CGPoint)hitPointForAlertButton:(XCUIElement *)alertButton {
-    if ([alertButton respondsToSelector:@selector(resolve)]) {
-        [alertButton resolve];
-    } else {
-        NSError *error = nil;
-        if (![alertButton resolveOrRaiseTestFailure:NO error:&error]) {
-            DDLogWarn(@"Encountered an error resolving element '%@':\n%@",
-                    alertButton, [error localizedDescription]);
-        }
-    }
+    [alertButton cbx_resolve];
 
     XCElementSnapshot *snapshot = alertButton.lastSnapshot;
 

--- a/Server/AutomationActions/Gestures/ClearText.m
+++ b/Server/AutomationActions/Gestures/ClearText.m
@@ -207,15 +207,7 @@
     XCUIElement *deleteKey = elements[0];
 
     if (!deleteKey.lastSnapshot) {
-        if ([deleteKey respondsToSelector:@selector(resolve)]) {
-            [deleteKey resolve];
-        } else {
-            NSError *error = nil;
-            if (![deleteKey resolveOrRaiseTestFailure:NO error:&error]) {
-                DDLogWarn(@"Encountered an error resolving element '%@':\n%@",
-                        deleteKey, [error localizedDescription]);
-            }
-        }
+        [deleteKey cbx_resolve];
     }
 
     return deleteKey;

--- a/Server/XCTest+CBXAdditions.h
+++ b/Server/XCTest+CBXAdditions.h
@@ -63,13 +63,19 @@
 @interface XCUIElement (CBXAdditions)
 
 - (XCElementSnapshot *_Nullable)lastSnapshot;
-- (void)resolveOrRaiseTestFailure;
-- (BOOL)resolveOrRaiseTestFailure:(BOOL)arg1 error:(id _Nonnull *_Nonnull)arg2;
 - (XCUICoordinate *_Nonnull)hitPointCoordinate;
 - (XCUIElementQuery *_Nonnull)query;
 
-// Removed in Xcode 11.0
+// Deprecated since Xcode 11.0
 - (void)resolve;
+// Added since Xcode 11.0
+- (void)resolveOrRaiseTestFailure;
+- (BOOL)resolveOrRaiseTestFailure:(BOOL)arg1 error:(id _Nonnull *_Nonnull)arg2;
+
+/**
+ Resolve element
+ */
+- (void)cbx_resolve;
 @end
 
 @interface XCElementSnapshot (CBXAdditions)

--- a/Server/XCTest+CBXAdditions.m
+++ b/Server/XCTest+CBXAdditions.m
@@ -74,15 +74,7 @@
     [invocation getReturnValue:&buffer];
     element = (__bridge XCUIElement *)buffer;
 
-    if ([element respondsToSelector:@selector(resolve)]) {
-        [element resolve];
-    } else {
-        NSError *error = nil;
-        if (![element resolveOrRaiseTestFailure:NO error:&error]) {
-            DDLogWarn(@"Encountered an error resolving element '%@':\n%@",
-                    element, [error localizedDescription]);
-        }
-    }
+    [element cbx_resolve];
 }
 
 - (XCUIElementQuery *_Nonnull)cbxQueryForDescendantsOfAnyType {
@@ -113,6 +105,17 @@
     return query;
 }
 
+@end
+
+@implementation XCUIElement (CBXAdditions)
+- (void)cbx_resolve
+{
+    if ([self respondsToSelector:@selector(resolve)]) {
+        [self resolve];
+    } else {
+        [self resolveOrRaiseTestFailure];
+    }
+}
 @end
 
 @implementation XCUIElementQuery (CBXAdditions)

--- a/Server/XCTest+CBXAdditions.m
+++ b/Server/XCTest+CBXAdditions.m
@@ -108,20 +108,22 @@
 @end
 
 @implementation XCUIElement (CBXAdditions)
-- (void)cbx_resolve
-{
+- (void)cbx_resolve {
     if ([self respondsToSelector:@selector(resolve)]) {
         [self resolve];
     } else {
-        [self resolveOrRaiseTestFailure];
+        NSError *error = nil;
+        if (![self resolveOrRaiseTestFailure:NO error:&error]) {
+            DDLogWarn(@"Encountered an error resolving element '%@':\n%@",
+                    self, [error localizedDescription]);
+        }
     }
 }
 @end
 
 @implementation XCUIElementQuery (CBXAdditions)
 
-- (XCElementSnapshot *)cbx_elementSnapshotForDebugDescription
-{
+- (XCElementSnapshot *)cbx_elementSnapshotForDebugDescription {
   if ([self respondsToSelector:@selector(elementSnapshotForDebugDescription)]) {
     return [self elementSnapshotForDebugDescription];
   }


### PR DESCRIPTION
DeviceAgent.iOS codebase contains a lot of occurences of the following code:
```
if ([button respondsToSelector:@selector(resolve)]) {
  [button resolve];
} else {
  [button resolveOrRaiseTestFailure];
}
```

This PR makes small refactoring:
1) Add method `cbx_resolve`
2) invoke `cbx_resolve` instead of a big condition above