### PR TITLE
Add Xcode 11.1 and Xcode 11.2 to the test matrix

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -37,6 +37,12 @@ jobs:
       Mojave-Xcode-11.0:
         IMAGE_POOL: 'macOS-10.14'
         XCODE_VERSION: '11'
+      Mojave-Xcode-11.1:
+        IMAGE_POOL: 'macOS-10.14'
+        XCODE_VERSION: '11.1'
+      Mojave-Xcode-11.2:
+        IMAGE_POOL: 'macOS-10.14'
+        XCODE_VERSION: '11.2'
   pool:
     vmImage: $(IMAGE_POOL)
   variables:


### PR DESCRIPTION
In scope of this PR we have added Xcode 11.1 and Xcode 11.2 to the test matrix