### PR TITLE
Add iPhone SE 2 to the formFactorMap

### DIFF
--- a/Server/Utilities/CBXDevice.m
+++ b/Server/Utilities/CBXDevice.m
@@ -263,6 +263,9 @@ NSString *const CBXDeviceSimKeyVersionInfo = @"SIMULATOR_VERSION_INFO";
       @"iPhone12,3" : @"iphone 10",
       @"iPhone12,5" : @"iphone 10s max",
 
+      // iPhone SE 2020
+      @"iPhone12,8" : @"iPhone 6",
+
       // iPad Pro 13in
       @"iPad6,7" : @"ipad pro",
       @"iPad6,8" : @"ipad pro",


### PR DESCRIPTION
iPhone SE 2 was introduced with Xcode 11.5 beta.
We added it to the `formFactorMap`.