### PR TITLE
[Support] Fix identifier implicit assertion issue in debug log for no…

### DIFF
--- a/Server/Application/Application.m
+++ b/Server/Application/Application.m
@@ -98,7 +98,7 @@ static Application *currentApplication;
 + (XCUIApplicationState)terminateApplication:(XCUIApplication *)application {
     NSTimeInterval startTime = [[CBXMachClock sharedClock] absoluteTime];
     if (application.state == XCUIApplicationStateNotRunning) {
-        DDLogDebug(@"Application %@ is not running", application.identifier);
+        DDLogDebug(@"Application %@ is not running", application.bundleID);
         return XCUIApplicationStateNotRunning;
     }
 


### PR DESCRIPTION
"DDLogDebug(@"Application %@ is not running", application.identifier);" causes 2 issues:
1. Unclear error message "Application (null) is not running" in case user call session_delete 2 times in a row
2. driver loses visibility and return empty hash stub in case session_delete called 2 times in a row and then start any app. It looks like due to implicit assertion issue: "DeviceAgent-Runner[13550:427853] 2020-06-04 13:21:00.285 DEBUG RoutingHTTPServer:225 | DELETE /1.0/session 
    t =    48.42s Find the Application 'com.my.app.dev'
    t =    48.43s     Collecting extra data to assist test failure triage
    t =    48.54s     Assertion Failure: Application.m:101: Failed to get matching snapshot: Application com.my.app.dev is not running""

Fix is simple: use bundleId to read property directly.