### PR TITLE
Fixed make scripts to build DeviceAgent.

### DIFF
--- a/AppStub/Info.plist
+++ b/AppStub/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.2.6</string>
+	<string>2.2.7</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/DeviceAgent.xcodeproj/project.pbxproj
+++ b/DeviceAgent.xcodeproj/project.pbxproj
@@ -4477,6 +4477,7 @@
 		F5954E1D1CBD2E1200117745 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				"ARCHS[sdk=iphonesimulator*]" = x86_64;
 				ASSETCATALOG_COMPILER_APPICON_NAME = TestAppIcon;
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_ENABLE_MODULES = YES;
@@ -4484,8 +4485,6 @@
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DEVELOPMENT_TEAM = FYD86LA7RE;
 				ENABLE_BITCODE = NO;
-				EXCLUDED_ARCHS = armv7s;
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/Vendor",
@@ -4518,14 +4517,13 @@
 		F5954E1E1CBD2E1200117745 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				"ARCHS[sdk=iphonesimulator*]" = x86_64;
 				ASSETCATALOG_COMPILER_APPICON_NAME = TestAppIcon;
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "iPhone Developer: Karl Krukow (YTTN6Y2QS9)";
 				DEVELOPMENT_TEAM = FYD86LA7RE;
 				ENABLE_BITCODE = NO;
-				EXCLUDED_ARCHS = armv7s;
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/Vendor",

--- a/DeviceAgent.xcodeproj/project.pbxproj
+++ b/DeviceAgent.xcodeproj/project.pbxproj
@@ -4147,6 +4147,7 @@
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DEVELOPMENT_TEAM = FYD86LA7RE;
 				ENABLE_BITCODE = NO;
+				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
 				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = AppStub/Info.plist;
 				INFOPLIST_PREFIX_HEADER = AppStub/InfoPlist.h;
@@ -4173,6 +4174,7 @@
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DEVELOPMENT_TEAM = FYD86LA7RE;
 				ENABLE_BITCODE = NO;
+				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
 				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = AppStub/Info.plist;
 				INFOPLIST_PREFIX_HEADER = AppStub/InfoPlist.h;
@@ -4522,8 +4524,7 @@
 				CODE_SIGN_IDENTITY = "iPhone Developer: Karl Krukow (YTTN6Y2QS9)";
 				DEVELOPMENT_TEAM = FYD86LA7RE;
 				ENABLE_BITCODE = NO;
-				EXCLUDED_ARCHS = "";
-				"EXCLUDED_ARCHS[sdk=*]" = armv7s;
+				EXCLUDED_ARCHS = armv7s;
 				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",

--- a/DeviceAgent.xcodeproj/project.pbxproj
+++ b/DeviceAgent.xcodeproj/project.pbxproj
@@ -4141,13 +4141,13 @@
 		898743DF1C5847B30084FD93 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				"ARCHS[sdk=iphonesimulator*]" = x86_64;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppStubIcon;
 				CLANG_ENABLE_MODULES = NO;
 				CODE_SIGN_IDENTITY = "iPhone Developer: Karl Krukow (YTTN6Y2QS9)";
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DEVELOPMENT_TEAM = FYD86LA7RE;
 				ENABLE_BITCODE = NO;
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
 				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = AppStub/Info.plist;
 				INFOPLIST_PREFIX_HEADER = AppStub/InfoPlist.h;
@@ -4168,13 +4168,13 @@
 		898743E01C5847B30084FD93 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				"ARCHS[sdk=iphonesimulator*]" = x86_64;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppStubIcon;
 				CLANG_ENABLE_MODULES = NO;
 				CODE_SIGN_IDENTITY = "iPhone Developer: Karl Krukow (YTTN6Y2QS9)";
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DEVELOPMENT_TEAM = FYD86LA7RE;
 				ENABLE_BITCODE = NO;
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
 				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = AppStub/Info.plist;
 				INFOPLIST_PREFIX_HEADER = AppStub/InfoPlist.h;
@@ -4194,13 +4194,13 @@
 		898743E21C5847B30084FD93 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				"ARCHS[sdk=iphonesimulator*]" = x86_64;
 				CLANG_ENABLE_CODE_COVERAGE = NO;
 				CLANG_ENABLE_MODULES = NO;
 				CODE_SIGN_IDENTITY = "iPhone Developer: Karl Krukow (YTTN6Y2QS9)";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer: Karl Krukow (YTTN6Y2QS9)";
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DEVELOPMENT_TEAM = FYD86LA7RE;
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/Carthage/Build/iOS",
@@ -4235,6 +4235,7 @@
 		898743E31C5847B30084FD93 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				"ARCHS[sdk=iphonesimulator*]" = x86_64;
 				CLANG_ENABLE_CODE_COVERAGE = NO;
 				CLANG_ENABLE_MODULES = NO;
 				CODE_SIGN_IDENTITY = "iPhone Developer: Karl Krukow (YTTN6Y2QS9)";
@@ -4242,7 +4243,6 @@
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DEVELOPMENT_TEAM = FYD86LA7RE;
 				EXCLUDED_ARCHS = "";
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/Carthage/Build/iOS",

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -34,6 +34,9 @@ jobs:
       Catalina-Xcode-12.4:
         IMAGE_POOL: 'macOS-10.15'
         XCODE_VERSION: '12.4'
+      BigSur-Xcode-12.5:
+        IMAGE_POOL: 'macOS-11.0'
+        XCODE_VERSION: '12.5'
   pool:
     vmImage: $(IMAGE_POOL)
   timeoutInMinutes: 120

--- a/bin/make/app-agent.sh
+++ b/bin/make/app-agent.sh
@@ -16,8 +16,8 @@ else
   XC_PIPE='cat'
 fi
 
-XC_TARGET="DeviceAgent"
-XC_PROJECT="DeviceAgent.xcodeproj"
+XC_WORKSPACE="DeviceAgent.xcworkspace"
+XC_SCHEME="DeviceAgent"
 XC_CONFIG=Debug
 
 XC_BUILD_DIR="build/app/DeviceAgent"
@@ -53,11 +53,11 @@ banner "Building ${APP}"
 
 COMMAND_LINE_BUILD=1 xcrun xcodebuild  \
   -SYMROOT="${XC_BUILD_DIR}" \
-  BUILT_PRODUCTS_DIR="${BUILD_PRODUCTS_DIR}" \
   TARGET_BUILD_DIR="${BUILD_PRODUCTS_DIR}" \
   DWARF_DSYM_FOLDER_PATH="${BUILD_PRODUCTS_DIR}" \
-  -project "${XC_PROJECT}" \
-  -target "${XC_TARGET}" \
+  -derivedDataPath "${BUILD_PRODUCTS_DIR}" \
+  -workspace "${XC_WORKSPACE}" \
+  -scheme "${XC_SCHEME}" \
   -configuration "${XC_CONFIG}" \
   -sdk iphonesimulator \
   ARCHS="x86_64" \
@@ -78,7 +78,7 @@ fi
 if [ "$(xcode_gte_9)" = "true" ]; then
   banner "Patching for Xcode >= 9"
 
-  XCTEST_BUNDLE="${XC_TARGET}.xctest"
+  XCTEST_BUNDLE="${XC_SCHEME}.xctest"
   BUILD_PRODUCTS_XCTEST="${BUILD_PRODUCTS_DIR}/${XCTEST_BUNDLE}"
   RUNNER_PLUGINS="${BUILD_PRODUCTS_RUNNER}/PlugIns"
   mkdir -p "${RUNNER_PLUGINS}"

--- a/bin/make/test-app.sh
+++ b/bin/make/test-app.sh
@@ -14,8 +14,8 @@ else
   XC_PIPE='cat'
 fi
 
-XC_TARGET="TestApp"
-XC_PROJECT="DeviceAgent.xcodeproj"
+XC_SCHEME="TestApp"
+XC_WORKSPACE="DeviceAgent.xcworkspace"
 XC_CONFIG=Debug
 
 XC_BUILD_DIR="build/app/TestApp"
@@ -49,11 +49,11 @@ banner "Building ${APP}"
 
 COMMAND_LINE_BUILD=1 xcrun xcodebuild  \
   -SYMROOT="${XC_BUILD_DIR}" \
-  BUILT_PRODUCTS_DIR="${BUILD_PRODUCTS_DIR}" \
+  -derivedDataPath "${BUILD_PRODUCTS_DIR}" \
   TARGET_BUILD_DIR="${BUILD_PRODUCTS_DIR}" \
   DWARF_DSYM_FOLDER_PATH="${BUILD_PRODUCTS_DIR}" \
-  -project "${XC_PROJECT}" \
-  -target "${XC_TARGET}" \
+  -workspace "${XC_WORKSPACE}" \
+  -scheme "${XC_SCHEME}" \
   -configuration "${XC_CONFIG}" \
   -sdk iphonesimulator \
   ARCHS="x86_64" \
@@ -80,7 +80,7 @@ install_with_ditto "${BUILD_PRODUCTS_DSYM}" "${INSTALLED_DSYM}"
 install_with_ditto "${BUILD_PRODUCTS_DSYM}" \
   "${INSTALL_DIR}/DeviceAgent-sim.app.dSYM"
 
-CAL_VERSION=`xcrun strings "${INSTALLED_APP}/${XC_TARGET}" | grep -E 'CALABASH VERSION'`
+CAL_VERSION=`xcrun strings "${INSTALLED_APP}/${XC_SCHEME}" | grep -E 'CALABASH VERSION'`
 info "${CAL_VERSION}"
 
 echo ""

--- a/bin/make/test-ipa.sh
+++ b/bin/make/test-ipa.sh
@@ -14,8 +14,8 @@ else
   XC_PIPE='cat'
 fi
 
-XC_TARGET="TestApp"
-XC_PROJECT="DeviceAgent.xcodeproj"
+XC_SCHEME="TestApp"
+XC_WORKSPACE="DeviceAgent.xcworkspace"
 XC_CONFIG=Debug
 
 XC_BUILD_DIR="build/ipa/TestApp"
@@ -51,11 +51,11 @@ if [ "${PREPARE_TC_ONLY}" != "1" ]; then
 
   COMMAND_LINE_BUILD=1 xcrun xcodebuild \
     -SYMROOT="${XC_BUILD_DIR}" \
-    BUILT_PRODUCTS_DIR="${BUILD_PRODUCTS_DIR}" \
+    -derivedDataPath "${BUILD_PRODUCTS_DIR}" \
     TARGET_BUILD_DIR="${BUILD_PRODUCTS_DIR}" \
     DWARF_DSYM_FOLDER_PATH="${BUILD_PRODUCTS_DIR}" \
-    -project "${XC_PROJECT}" \
-    -target "${XC_TARGET}" \
+    -workspace "${XC_WORKSPACE}" \
+    -scheme "${XC_SCHEME}" \
     -configuration "${XC_CONFIG}" \
     -sdk iphoneos \
     ARCHS="arm64" \
@@ -97,7 +97,7 @@ if [ "${PREPARE_TC_ONLY}" != "1" ]; then
 
   echo ""
 
-  CAL_VERSION=`xcrun strings "${INSTALLED_APP}/${XC_TARGET}" | grep -E 'CALABASH VERSION' | head -n 1`
+  CAL_VERSION=`xcrun strings "${INSTALLED_APP}/${XC_SCHEME}" | grep -E 'CALABASH VERSION' | head -n 1`
   info "${CAL_VERSION}"
 
   echo ""


### PR DESCRIPTION
When building with Xcode 12.5 the error was:

`error: mkdir(/build, S_IRWXU | S_IRWXG | S_IRWXO): Read-only file system (30)


** BUILD FAILED **


The following build commands failed:
	CreateBuildDirectory /build/ipa/TestApp/Build/Products/Debug-iphoneos
(1 failure)
ERROR: Building ipa failed.
make: *** [test-ipa] Error 65`