### PR TITLE
Added "Apple ID Required notification" 

### DIFF
--- a/Server/Resources.xcassets/springboard-alerts/springboard-alerts-ar.dataset/alerts.json
+++ b/Server/Resources.xcassets/springboard-alerts/springboard-alerts-ar.dataset/alerts.json
@@ -474,5 +474,12 @@
       "ليس الآن"
     ],
     "shouldAccept": true
+  },
+  {
+    "title": "مطلوب Apple ID",
+    "buttons": [
+      "ليس الآ"
+    ],
+    "shouldAccept": false
   }
 ]

--- a/Server/Resources.xcassets/springboard-alerts/springboard-alerts-ca.dataset/alerts.json
+++ b/Server/Resources.xcassets/springboard-alerts/springboard-alerts-ca.dataset/alerts.json
@@ -491,5 +491,12 @@
       "OK"
     ],
     "shouldAccept": true
+  },
+  {
+    "title": "ID d’Apple obligatori",
+    "buttons": [
+      "Ara no"
+    ],
+    "shouldAccept": false
   }
 ]

--- a/Server/Resources.xcassets/springboard-alerts/springboard-alerts-cs.dataset/alerts.json
+++ b/Server/Resources.xcassets/springboard-alerts/springboard-alerts-cs.dataset/alerts.json
@@ -530,5 +530,12 @@
       "OK"
     ],
     "shouldAccept": true
+  },
+  {
+    "title": "Je požadováno Apple ID",
+    "buttons": [
+      "Teď ne"
+    ],
+    "shouldAccept": false
   }
 ]

--- a/Server/Resources.xcassets/springboard-alerts/springboard-alerts-da.dataset/alerts.json
+++ b/Server/Resources.xcassets/springboard-alerts/springboard-alerts-da.dataset/alerts.json
@@ -480,5 +480,12 @@
       "Tillad"
     ],
     "shouldAccept": true
+  },
+  {
+    "title": "Apple-id kræves",
+    "buttons": [
+      "Ikke nu"
+    ],
+    "shouldAccept": false
   }
 ]

--- a/Server/Resources.xcassets/springboard-alerts/springboard-alerts-de.dataset/alerts.json
+++ b/Server/Resources.xcassets/springboard-alerts/springboard-alerts-de.dataset/alerts.json
@@ -720,5 +720,12 @@
       "Erlauben"
     ],
     "shouldAccept": true
+  },
+  {
+    "title": "Apple‑ID erforderlich",
+    "buttons": [
+      "Später"
+    ],
+    "shouldAccept": false
   }
 ]

--- a/Server/Resources.xcassets/springboard-alerts/springboard-alerts-el.dataset/alerts.json
+++ b/Server/Resources.xcassets/springboard-alerts/springboard-alerts-el.dataset/alerts.json
@@ -563,5 +563,12 @@
       "Ναι"
     ],
     "shouldAccept": true
+  },
+  {
+    "title": "Απαιτείται Apple ID",
+    "buttons": [
+      "Όχι τώρα"
+    ],
+    "shouldAccept": false
   }
 ]

--- a/Server/Resources.xcassets/springboard-alerts/springboard-alerts-en.dataset/alerts.json
+++ b/Server/Resources.xcassets/springboard-alerts/springboard-alerts-en.dataset/alerts.json
@@ -476,5 +476,12 @@
       "Allow"
     ],
     "shouldAccept": true
+  },
+  {
+    "title": "Apple ID Required",
+    "buttons": [
+      "Not Now"
+    ],
+    "shouldAccept": false
   }
 ]

--- a/Server/Resources.xcassets/springboard-alerts/springboard-alerts-en_AU.dataset/alerts.json
+++ b/Server/Resources.xcassets/springboard-alerts/springboard-alerts-en_AU.dataset/alerts.json
@@ -455,5 +455,12 @@
       "Allow"
     ],
     "shouldAccept": true
+  },
+  {
+    "title": "Apple ID Required",
+    "buttons": [
+      "Not Now"
+    ],
+    "shouldAccept": false
   }
 ]

--- a/Server/Resources.xcassets/springboard-alerts/springboard-alerts-en_GB.dataset/alerts.json
+++ b/Server/Resources.xcassets/springboard-alerts/springboard-alerts-en_GB.dataset/alerts.json
@@ -455,5 +455,12 @@
       "Allow"
     ],
     "shouldAccept": true
+  },
+  {
+    "title": "Apple ID Required",
+    "buttons": [
+      "Not Now"
+    ],
+    "shouldAccept": false
   }
 ]

--- a/Server/Resources.xcassets/springboard-alerts/springboard-alerts-es.dataset/alerts.json
+++ b/Server/Resources.xcassets/springboard-alerts/springboard-alerts-es.dataset/alerts.json
@@ -514,5 +514,12 @@
       "Permitir"
     ],
     "shouldAccept": true
+  },
+  {
+    "title": "ID de Apple necesario",
+    "buttons": [
+      "Ahora no"
+    ],
+    "shouldAccept": false
   }
 ]

--- a/Server/Resources.xcassets/springboard-alerts/springboard-alerts-es_419.dataset/alerts.json
+++ b/Server/Resources.xcassets/springboard-alerts/springboard-alerts-es_419.dataset/alerts.json
@@ -461,5 +461,12 @@
       "Ahora no"
     ],
     "shouldAccept": false
+  },
+  {
+    "title": "ID de Apple necesario",
+    "buttons": [
+      "Ahora no"
+    ],
+    "shouldAccept": false
   }
 ]

--- a/Server/Resources.xcassets/springboard-alerts/springboard-alerts-fi.dataset/alerts.json
+++ b/Server/Resources.xcassets/springboard-alerts/springboard-alerts-fi.dataset/alerts.json
@@ -460,5 +460,12 @@
       "OK"
     ],
     "shouldAccept": true
+  },
+  {
+    "title": "Vaaditaan Apple ID",
+    "buttons": [
+      "Ei nyt"
+    ],
+    "shouldAccept": false
   }
 ]

--- a/Server/Resources.xcassets/springboard-alerts/springboard-alerts-fr.dataset/alerts.json
+++ b/Server/Resources.xcassets/springboard-alerts/springboard-alerts-fr.dataset/alerts.json
@@ -456,5 +456,12 @@
       "Plus tard"
     ],
     "shouldAccept": true
+  },
+  {
+    "title": "Identifiant Apple requis",
+    "buttons": [
+      "Plus tard"
+    ],
+    "shouldAccept": false
   }
 ]

--- a/Server/Resources.xcassets/springboard-alerts/springboard-alerts-fr_CA.dataset/alerts.json
+++ b/Server/Resources.xcassets/springboard-alerts/springboard-alerts-fr_CA.dataset/alerts.json
@@ -432,5 +432,12 @@
       "Autoriser"
     ],
     "shouldAccept": true
+  },
+  {
+    "title": "Identifiant Apple requis",
+    "buttons": [
+      "Plus tard"
+    ],
+    "shouldAccept": false
   }
 ]

--- a/Server/Resources.xcassets/springboard-alerts/springboard-alerts-he.dataset/alerts.json
+++ b/Server/Resources.xcassets/springboard-alerts/springboard-alerts-he.dataset/alerts.json
@@ -478,5 +478,12 @@
       "אישור"
     ],
     "shouldAccept": true
+  },
+  {
+    "title": "נדרש Apple ID",
+    "buttons": [
+      "לא כעת"
+    ],
+    "shouldAccept": false
   }
 ]

--- a/Server/Resources.xcassets/springboard-alerts/springboard-alerts-hi.dataset/alerts.json
+++ b/Server/Resources.xcassets/springboard-alerts/springboard-alerts-hi.dataset/alerts.json
@@ -629,5 +629,12 @@
       "अनुमति न दें"
     ],
     "shouldAccept": false
+  },
+  {
+    "title": "Apple ID आवश्यक",
+    "buttons": [
+      "अभी नहीं"
+    ],
+    "shouldAccept": false
   }
 ]

--- a/Server/Resources.xcassets/springboard-alerts/springboard-alerts-hr.dataset/alerts.json
+++ b/Server/Resources.xcassets/springboard-alerts/springboard-alerts-hr.dataset/alerts.json
@@ -477,5 +477,12 @@
       "Nemoj dozvoliti"
     ],
     "shouldAccept": false
+  },
+  {
+    "title": "Potreban je Apple ID",
+    "buttons": [
+      "Ne sad"
+    ],
+    "shouldAccept": false
   }
 ]

--- a/Server/Resources.xcassets/springboard-alerts/springboard-alerts-hu.dataset/alerts.json
+++ b/Server/Resources.xcassets/springboard-alerts/springboard-alerts-hu.dataset/alerts.json
@@ -547,5 +547,12 @@
       "Tiltás"
     ],
     "shouldAccept": false
+  },
+  {
+    "title": "Apple ID szükséges",
+    "buttons": [
+      "Ne most"
+    ],
+    "shouldAccept": false
   }
 ]

--- a/Server/Resources.xcassets/springboard-alerts/springboard-alerts-id.dataset/alerts.json
+++ b/Server/Resources.xcassets/springboard-alerts/springboard-alerts-id.dataset/alerts.json
@@ -451,5 +451,12 @@
       "Izinkan"
     ],
     "shouldAccept": true
+  },
+  {
+    "title": "ID Apple Diperlukan",
+    "buttons": [
+      "Nanti"
+    ],
+    "shouldAccept": false
   }
 ]

--- a/Server/Resources.xcassets/springboard-alerts/springboard-alerts-it.dataset/alerts.json
+++ b/Server/Resources.xcassets/springboard-alerts/springboard-alerts-it.dataset/alerts.json
@@ -494,5 +494,12 @@
       "Non ora"
     ],
     "shouldAccept": true
+  },
+  {
+    "title": "È richiesto un ID Apple",
+    "buttons": [
+      "Non ora"
+    ],
+    "shouldAccept": false
   }
 ]

--- a/Server/Resources.xcassets/springboard-alerts/springboard-alerts-ja.dataset/alerts.json
+++ b/Server/Resources.xcassets/springboard-alerts/springboard-alerts-ja.dataset/alerts.json
@@ -453,5 +453,12 @@
       "許可"
     ],
     "shouldAccept": true
+  },
+  {
+    "title": "Apple IDが必要です",
+    "buttons": [
+      "今はしない"
+    ],
+    "shouldAccept": false
   }
 ]

--- a/Server/Resources.xcassets/springboard-alerts/springboard-alerts-ko.dataset/alerts.json
+++ b/Server/Resources.xcassets/springboard-alerts/springboard-alerts-ko.dataset/alerts.json
@@ -559,5 +559,12 @@
       "허용 안 함"
     ],
     "shouldAccept": false
+  },
+  {
+    "title": "Apple ID 필요",
+    "buttons": [
+      "지금 안 함"
+    ],
+    "shouldAccept": false
   }
 ]

--- a/Server/Resources.xcassets/springboard-alerts/springboard-alerts-ms.dataset/alerts.json
+++ b/Server/Resources.xcassets/springboard-alerts/springboard-alerts-ms.dataset/alerts.json
@@ -524,5 +524,12 @@
       "Bukan Sekarang"
     ],
     "shouldAccept": false
+  },
+  {
+    "title": "Apple ID Diperlukan",
+    "buttons": [
+      "Bukan Sekarang"
+    ],
+    "shouldAccept": false
   }
 ]

--- a/Server/Resources.xcassets/springboard-alerts/springboard-alerts-nl.dataset/alerts.json
+++ b/Server/Resources.xcassets/springboard-alerts/springboard-alerts-nl.dataset/alerts.json
@@ -517,5 +517,12 @@
       "Sta toe"
     ],
     "shouldAccept": true
+  },
+  {
+    "title": "Apple ID vereist",
+    "buttons": [
+      "Niet nu"
+    ],
+    "shouldAccept": false
   }
 ]

--- a/Server/Resources.xcassets/springboard-alerts/springboard-alerts-no.dataset/alerts.json
+++ b/Server/Resources.xcassets/springboard-alerts/springboard-alerts-no.dataset/alerts.json
@@ -587,5 +587,12 @@
       "Tillat"
     ],
     "shouldAccept": true
+  },
+  {
+    "title": "Apple‑ID kreves",
+    "buttons": [
+      "Ikke nå"
+    ],
+    "shouldAccept": false
   }
 ]

--- a/Server/Resources.xcassets/springboard-alerts/springboard-alerts-pl.dataset/alerts.json
+++ b/Server/Resources.xcassets/springboard-alerts/springboard-alerts-pl.dataset/alerts.json
@@ -474,5 +474,12 @@
       "Pozwól"
     ],
     "shouldAccept": true
+  },
+  {
+    "title": "Wymagany Apple ID",
+    "buttons": [
+      "Nie teraz"
+    ],
+    "shouldAccept": false
   }
 ]

--- a/Server/Resources.xcassets/springboard-alerts/springboard-alerts-ro.dataset/alerts.json
+++ b/Server/Resources.xcassets/springboard-alerts/springboard-alerts-ro.dataset/alerts.json
@@ -433,5 +433,12 @@
       "Permiteți"
     ],
     "shouldAccept": true
+  },
+  {
+    "title": "ID Apple necesar",
+    "buttons": [
+      "Nu acum"
+    ],
+    "shouldAccept": false
   }
 ]

--- a/Server/Resources.xcassets/springboard-alerts/springboard-alerts-ru.dataset/alerts.json
+++ b/Server/Resources.xcassets/springboard-alerts/springboard-alerts-ru.dataset/alerts.json
@@ -624,5 +624,12 @@
       "Разрешить"
     ],
     "shouldAccept": true
+  },
+  {
+    "title": "Требуется Apple ID",
+    "buttons": [
+      "Не сейчас"
+    ],
+    "shouldAccept": false
   }
 ]

--- a/Server/Resources.xcassets/springboard-alerts/springboard-alerts-sk.dataset/alerts.json
+++ b/Server/Resources.xcassets/springboard-alerts/springboard-alerts-sk.dataset/alerts.json
@@ -720,5 +720,12 @@
       "Povoliť"
     ],
     "shouldAccept": true
+  },
+  {
+    "title": "Vyžaduje sa Apple ID",
+    "buttons": [
+      "Teraz nie"
+    ],
+    "shouldAccept": false
   }
 ]

--- a/Server/Resources.xcassets/springboard-alerts/springboard-alerts-sv.dataset/alerts.json
+++ b/Server/Resources.xcassets/springboard-alerts/springboard-alerts-sv.dataset/alerts.json
@@ -426,5 +426,12 @@
       "Tillåt"
     ],
     "shouldAccept": true
+  },
+  {
+    "title": "Apple-ID krävs",
+    "buttons": [
+      "Inte nu"
+    ],
+    "shouldAccept": false
   }
 ]

--- a/Server/Resources.xcassets/springboard-alerts/springboard-alerts-th.dataset/alerts.json
+++ b/Server/Resources.xcassets/springboard-alerts/springboard-alerts-th.dataset/alerts.json
@@ -538,5 +538,12 @@
       "ตกลง"
     ],
     "shouldAccept": true
+  },
+  {
+    "title": "ต้องใช้ Apple ID",
+    "buttons": [
+      "ไม่ใช่ตอนนี้"
+    ],
+    "shouldAccept": false
   }
 ]

--- a/Server/Resources.xcassets/springboard-alerts/springboard-alerts-tr.dataset/alerts.json
+++ b/Server/Resources.xcassets/springboard-alerts/springboard-alerts-tr.dataset/alerts.json
@@ -510,5 +510,12 @@
       "Sonra"
     ],
     "shouldAccept": true
+  },
+  {
+    "title": "Apple Kimliği Gerekli",
+    "buttons": [
+      "Sonra"
+    ],
+    "shouldAccept": false
   }
 ]

--- a/Server/Resources.xcassets/springboard-alerts/springboard-alerts-uk.dataset/alerts.json
+++ b/Server/Resources.xcassets/springboard-alerts/springboard-alerts-uk.dataset/alerts.json
@@ -609,5 +609,12 @@
       "Не зараз"
     ],
     "shouldAccept": true
+  },
+  {
+    "title": "Потрібний Apple ID",
+    "buttons": [
+      "Не зараз"
+    ],
+    "shouldAccept": false
   }
 ]

--- a/Server/Resources.xcassets/springboard-alerts/springboard-alerts-vi.dataset/alerts.json
+++ b/Server/Resources.xcassets/springboard-alerts/springboard-alerts-vi.dataset/alerts.json
@@ -561,5 +561,12 @@
       "Để sau"
     ],
     "shouldAccept": true
+  },
+  {
+    "title": "Yêu cầu ID Apple",
+    "buttons": [
+      "Để sau"
+    ],
+    "shouldAccept": false
   }
 ]


### PR DESCRIPTION
Added for most of localizations, except:

pt_PT: "Portuguese (Portugal)"
pt_BR: "Portuguese (Brazil)"
zh_CN: "Chinese (Simplified)"
zh_HK: "Chinese (Simplified, Hong Kong SAR China)"
zh_TW: "Chinese (Traditional Taiwan)"

For these the notification will be added later