### PR TITLE
Revert SpringBoardAlerts.m changes to unblock customer when non en localisation is used. 

### DIFF
--- a/Server/Utilities/SpringBoardAlerts.m
+++ b/Server/Utilities/SpringBoardAlerts.m
@@ -97,7 +97,7 @@ static SpringBoardAlert *alert(NSArray *buttonTitles, BOOL shouldAccept, NSStrin
             // fix mismatching language name for Norwegian and Chinese languages
 
             // '.lproj' files uses '_' as separator. 'preferredLanguages' uses '-' as separator, need to convert
-            NSString *fullLanguageName = [fixedPreferredLanguage stringByReplacingOccurrencesOfString:@"-" withString: @"_"];
+            NSString *fullLanguageName = [fixedPreferredLanguage stringByReplacingOccurrencesOfString:@"-" withString:@"_"];
             // load exact name like "pt_PT"
             [self loadLanguageIfExists:fullLanguageName:resultArray];
             // load short name like "pt"
@@ -108,6 +108,11 @@ static SpringBoardAlert *alert(NSArray *buttonTitles, BOOL shouldAccept, NSStrin
             [self loadLanguageIfExists:fixedPreferredLanguage:resultArray];
         }
 
+            // load "en" lang
+        if (![preferredLanguage hasPrefix:@"en"]) {
+            [self loadLanguageIfExists:@"en": resultArray];
+        }
+        
         _alerts =  [NSArray<SpringBoardAlert *> arrayWithArray: resultArray];
         NSTimeInterval elapsedSeconds =
         [[CBXMachClock sharedClock] absoluteTime] - startTime;
@@ -120,9 +125,7 @@ static SpringBoardAlert *alert(NSArray *buttonTitles, BOOL shouldAccept, NSStrin
 // Some language names can be different in different Xcode versions
 // function maps language names to make sure that all xcode versions will work
 - (NSString *)fixLanguageName:(NSString *)languageName {
-    if (![languageName isEqualToString: @"en-US"]) {
-        return @"en";
-    } else if ([languageName isEqualToString: @"zh-Hans-US"]) {
+    if ([languageName isEqualToString: @"zh-Hans-US"]) {
         return @"zh-CN";
     } else if ([languageName isEqualToString: @"zh-Hant-US"]) {
         return @"zh-TW";


### PR DESCRIPTION
Springboard alert not being dismissed if ios language is not English. This is just a temporary solution to unblock customer. 